### PR TITLE
Remove irrelevant slash from the base url of file client

### DIFF
--- a/storageservice/modules/files/file_client.bal
+++ b/storageservice/modules/files/file_client.bal
@@ -32,7 +32,7 @@ public client class FileClient {
     # + azureConfig - AzureFileServiceConfiguration record
     public isolated function init(AzureFileServiceConfiguration azureConfig) returns error? {
         http:ClientSecureSocket? secureSocketConfig = azureConfig?.secureSocketConfig;
-        string baseURL = string `https://${azureConfig.accountName}.file.core.windows.net/`;
+        string baseURL = string `https://${azureConfig.accountName}.file.core.windows.net`;
         self.azureConfig = azureConfig;
         if (secureSocketConfig is http:ClientSecureSocket) {
             self.httpClient = check new (baseURL, {

--- a/storageservice/modules/files/management_client.bal
+++ b/storageservice/modules/files/management_client.bal
@@ -31,7 +31,7 @@ public client class ManagementClient {
     # + azureConfig - AzureConfiguration record
     public isolated function init(AzureFileServiceConfiguration azureConfig) returns error? {
         http:ClientSecureSocket? secureSocketConfig = azureConfig?.secureSocketConfig;
-        string baseURL = string `https://${azureConfig.accountName}.file.core.windows.net/`;
+        string baseURL = string `https://${azureConfig.accountName}.file.core.windows.net`;
         self.azureConfig = azureConfig;
         if (secureSocketConfig is http:ClientSecureSocket) {
             self.httpClient = check new (baseURL, {


### PR DESCRIPTION
## Purpose
Fix https://github.com/wso2-enterprise/choreo/issues/6080

## Goals
Remove irrelevant slash in base URL of client of Azure Storage Files

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> JDK 11
> SL Beta 2
 