### PR TITLE
Fix issue on having warning message on UploadLargeBlob function of the blobs module

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.caching=true
 group=org.ballerinalang.azure_storage_service
-version=1.0.1
+version=1.0.2
 ballerinaLangVersion=2.0.0-beta.2.1

--- a/storageservice/Ballerina.toml
+++ b/storageservice/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "azure_storage_service"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Ballerina"]
 export = ["azure_storage_service", "azure_storage_service.files", "azure_storage_service.blobs"]
 keywords = ["azure", "storage", "blob", "file"]

--- a/storageservice/modules/blobs/endpoint.bal
+++ b/storageservice/modules/blobs/endpoint.bal
@@ -701,12 +701,12 @@ public isolated client class BlobClient {
                 if (remainingBytes < MAX_BLOB_UPLOAD_SIZE) {
                     byte[] lastByteArray = byteBlock.value.slice(0, remainingBytes);
                     _ = check self->putBlock(containerName, blobName, blockId, lastByteArray);
-                    log:printInfo("Upload successful");
+                    log:printDebug("Upload successful");
                 } else {
                     _ = check self->putBlock(containerName, blobName, blockId, byteBlock.value);
                     remainingBytes -= MAX_BLOB_UPLOAD_SIZE;
-                    log:printInfo("Remaining bytes to upload: " + remainingBytes.toString() + "Bytes");
-                    i += 1;  
+                    log:printDebug("Remaining bytes to upload: " + remainingBytes.toString() + "Bytes");
+                    i = i + 1;  
                 }   
             }
         }

--- a/storageservice/modules/blobs/endpoint.bal
+++ b/storageservice/modules/blobs/endpoint.bal
@@ -677,7 +677,7 @@ public isolated client class BlobClient {
     # + filePath - Path to the file which should be uploaded
     # + return - error if unsuccessful
     @display {label: "Upload Blob From File"}
-    remote function uploadLargeBlob(@display {label: "Container Name"} string containerName, 
+    isolated remote function uploadLargeBlob(@display {label: "Container Name"} string containerName, 
                                     @display {label: "Blob Name"} string blobName, 
                                     @display {label: "File Path"} string filePath) returns @tainted error? {
         file:MetaData fileMetaData = check file:getMetaData(filePath);
@@ -687,23 +687,29 @@ public isolated client class BlobClient {
         int i = 0; // Index of current block
         int remainingBytes = fileSize; // Remaining bytes to upload
         string[] blockIdArray = []; // List of blockIds
+        boolean isOver = false;
 
-        var fileStream = check io:fileReadBlocksAsStream(filePath, MAX_BLOB_UPLOAD_SIZE);
-        error? e = fileStream.forEach(function(io:Block byteBlock) {
-            string blockId = blobName + COLON_SYMBOL + i.toString();
-            blockIdArray[i] = blockId;
-                    
-            if (remainingBytes < MAX_BLOB_UPLOAD_SIZE) {
-                byte[] lastByteArray = byteBlock.slice(0, remainingBytes);
-                _ = checkpanic self->putBlock(containerName, blobName, blockId, lastByteArray);
-                log:printInfo("Upload successful");
+        stream<io:Block, io:Error?> fileStream = check io:fileReadBlocksAsStream(filePath, MAX_BLOB_UPLOAD_SIZE);
+        while !isOver {
+            record {| byte[] & readonly value; |}? byteBlock  = check fileStream.next();
+            if(byteBlock is ()) {
+                isOver = true;
             } else {
-                _ = checkpanic self->putBlock(containerName, blobName, blockId, byteBlock);
-                remainingBytes -= MAX_BLOB_UPLOAD_SIZE;
-                log:printInfo("Remaining bytes to upload: " + remainingBytes.toString() + "Bytes");
-                i += 1;  
-            }             
-        });
+                string blockId = blobName + COLON_SYMBOL + i.toString();
+                blockIdArray[i] = blockId;
+                        
+                if (remainingBytes < MAX_BLOB_UPLOAD_SIZE) {
+                    byte[] lastByteArray = byteBlock.value.slice(0, remainingBytes);
+                    _ = check self->putBlock(containerName, blobName, blockId, lastByteArray);
+                    log:printInfo("Upload successful");
+                } else {
+                    _ = check self->putBlock(containerName, blobName, blockId, byteBlock.value);
+                    remainingBytes -= MAX_BLOB_UPLOAD_SIZE;
+                    log:printInfo("Remaining bytes to upload: " + remainingBytes.toString() + "Bytes");
+                    i += 1;  
+                }   
+            }
+        }
         _ = check self->putBlockList(containerName, blobName, blockIdArray);     
     }
 }


### PR DESCRIPTION
## Purpose
> Fixing the issue on having the warning message : `WARNING [endpoint.bal:(680:5,708:6)] function 'uploadLargeBlob' can be marked as an 'isolated' function`
Fixes https://github.com/wso2-enterprise/choreo/issues/7655
## Goals
> Remove the warning messages

## Approach
1. Remove foreach function of the uploadLargeBlob function
2. Isolated the function

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> Ballerina Swan Lake Beta2