### PR TITLE
Change the connector version to 0.1.3

### DIFF
--- a/Ballerina.toml
+++ b/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "azure_storage_service"
-version = "0.1.4"
+version = "0.1.3"
 authors = ["Ballerina"]
 export = ["azure_storage_service", "azure_storage_service.files", "azure_storage_service.blobs"]
 keywords = ["azure", "storage", "blob", "file"]


### PR DESCRIPTION
# Description
The latest version in prod central is 0.1.2
So updating version to 0.1.3 for the next release

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
