### PR TITLE
[SLBeta3] Remove irrelevant slash from the base url of file client for v0.1.3 release

### DIFF
--- a/modules/files/file_client.bal
+++ b/modules/files/file_client.bal
@@ -32,7 +32,7 @@ public client class FileClient {
     # + azureConfig - AzureFileServiceConfiguration record
     public isolated function init(AzureFileServiceConfiguration azureConfig) returns error? {
         http:ClientSecureSocket? secureSocketConfig = azureConfig?.secureSocketConfig;
-        string baseURL = string `https://${azureConfig.accountName}.file.core.windows.net/`;
+        string baseURL = string `https://${azureConfig.accountName}.file.core.windows.net`;
         self.azureConfig = azureConfig;
         if (secureSocketConfig is http:ClientSecureSocket) {
             self.httpClient = check new (baseURL, {

--- a/modules/files/management_client.bal
+++ b/modules/files/management_client.bal
@@ -31,7 +31,7 @@ public client class ManagementClient {
     # + azureConfig - AzureConfiguration record
     public isolated function init(AzureFileServiceConfiguration azureConfig) returns error? {
         http:ClientSecureSocket? secureSocketConfig = azureConfig?.secureSocketConfig;
-        string baseURL = string `https://${azureConfig.accountName}.file.core.windows.net/`;
+        string baseURL = string `https://${azureConfig.accountName}.file.core.windows.net`;
         self.azureConfig = azureConfig;
         if (secureSocketConfig is http:ClientSecureSocket) {
             self.httpClient = check new (baseURL, {


### PR DESCRIPTION
# Description
- Remove unwanted slash in base url of file clients
- This is to make v0.1.3 of the connector compatible with SLBeta3

### Related PR
https://github.com/ballerina-platform/module-ballerinax-azure-storage-service/pull/16

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
