### PR TITLE
[SLBeta3] Remove unnecessary whitespace in http:HTTP_GET 

### DIFF
--- a/storageservice/Ballerina.toml
+++ b/storageservice/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "azure_storage_service"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Ballerina"]
 export = ["azure_storage_service", "azure_storage_service.files", "azure_storage_service.blobs"]
 keywords = ["Content & Files/File Management & Storage", "Cost/Paid", "Vendor/Microsoft"]

--- a/storageservice/Dependencies.toml
+++ b/storageservice/Dependencies.toml
@@ -332,7 +332,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "azure_storage_service"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "file"},

--- a/storageservice/modules/files/management_client.bal
+++ b/storageservice/modules/files/management_client.bal
@@ -55,7 +55,7 @@ public isolated client class ManagementClient {
             AuthorizationDetail  authorizationDetail = {
                 azureRequest: request,
                 azureConfig: self.azureConfig,
-                httpVerb: http: HTTP_GET,
+                httpVerb: http:HTTP_GET,
                 uriParameterRecord: uriParameters,
                 requiredURIParameters: requiredURIParameters
             };


### PR DESCRIPTION
# Purpose
- Add the same fix as https://github.com/ballerina-platform/module-ballerinax-azure-storage-service/pull/37 to `slbeta3` branch

# Description
- Remove unnecessary whitespace in http:HTTP_GET

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 