### PR TITLE
Adding response content type validation to the operation `getFileAsByteArray`

### DIFF
--- a/storageservice/Ballerina.toml
+++ b/storageservice/Ballerina.toml
@@ -2,7 +2,7 @@
 distribution = "2201.0.1"
 org = "ballerinax"
 name = "azure_storage_service"
-version = "2.2.2"
+version = "2.2.3"
 authors = ["Ballerina"]
 export = ["azure_storage_service", "azure_storage_service.files", "azure_storage_service.blobs"]
 keywords = ["Content & Files/File Management & Storage", "Cost/Paid", "Vendor/Microsoft"]

--- a/storageservice/modules/files/file_client.bal
+++ b/storageservice/modules/files/file_client.bal
@@ -20,7 +20,7 @@ import ballerina/xmldata;
 
 # Azure Storage File connector allows you to access the Azure Files REST API.
 # This connector lets you to access data stored in Azure file shares.
-# 
+#
 # + httpClient - HTTP Client for Azure Storage File Service
 # + azureConfig - Azure file service configuration
 @display {label: "Azure Storage File", iconPath: "storageservice/icon.png"}
@@ -46,14 +46,14 @@ public isolated client class FileClient {
     # + fileShareName - Name of the FileShare
     # + azureDirectoryPath - Path of the Azure directory
     # + uriParameters - Map of the optional URI parameters record
-    # + return -  If success, DirectoryList record with Details and the marker. Else an error.
+    # + return - If success, DirectoryList record with Details and the marker. Else an error.
     @display {label: "Get Directory List"}
-    remote isolated function getDirectoryList(@display {label: "File Share Name"} string fileShareName, 
-                                              @display {label: "Azure Directory Path"} string? azureDirectoryPath = (), 
-                                              @display {label: "Optional URI Parameters Map"} GetFileListURIParameters 
-                                              uriParameters = {}) returns @display {label: "Response"} 
-                                              DirectoryList|error {
-        string requestPath = azureDirectoryPath is () ? (SLASH + fileShareName + SLASH + LIST_FILES_DIRECTORIES_PATH) 
+    remote isolated function getDirectoryList(@display {label: "File Share Name"} string fileShareName,
+                                            @display {label: "Azure Directory Path"} string? azureDirectoryPath = (),
+                                            @display {label: "Optional URI Parameters Map"} GetFileListURIParameters
+                                            uriParameters = {}) returns @display {label: "Response"}
+                                            DirectoryList|error {
+        string requestPath = azureDirectoryPath is () ? (SLASH + fileShareName + SLASH + LIST_FILES_DIRECTORIES_PATH)
             : SLASH + fileShareName + SLASH + azureDirectoryPath + SLASH + LIST_FILES_DIRECTORIES_PATH;
         string? optionalURIParameters = setOptionalURIParametersFromRecord(uriParameters);
         requestPath = optionalURIParameters is () ? requestPath : (requestPath + optionalURIParameters);
@@ -62,19 +62,19 @@ public isolated client class FileClient {
             map<string> requiredURIParameters = {};
             requiredURIParameters[RESTYPE] = DIRECTORY;
             requiredURIParameters[COMP] = LIST;
-            string resourcePathForSharedkeyAuth = azureDirectoryPath is () ? (fileShareName + SLASH) 
+            string resourcePathForSharedkeyAuth = azureDirectoryPath is () ? (fileShareName + SLASH)
                 : (fileShareName + SLASH + azureDirectoryPath + SLASH);
-            AuthorizationDetail  authorizationDetail = {
-                azureRequest:request,
-                azureConfig:self.azureConfig,
+            AuthorizationDetail authorizationDetail = {
+                azureRequest: request,
+                azureConfig: self.azureConfig,
                 httpVerb: http:HTTP_GET,
                 uriParameterRecord: uriParameters,
                 resourcePath: resourcePathForSharedkeyAuth,
                 requiredURIParameters: requiredURIParameters
             };
-            check prepareAuthorizationHeaders(authorizationDetail);       
+            check prepareAuthorizationHeaders(authorizationDetail);
         } else {
-            requestPath = requestPath.concat(AMPERSAND, self.azureConfig.accessKeyOrSAS.substring(1)); 
+            requestPath = requestPath.concat(AMPERSAND, self.azureConfig.accessKeyOrSAS.substring(1));
         }
         map<string> headerMap = populateHeaderMapFromRequest(request);
         http:Response response = check self.httpClient->get(requestPath, headerMap);
@@ -92,14 +92,14 @@ public isolated client class FileClient {
     # + fileShareName - Name of the FileShare
     # + azureDirectoryPath - Path of the Azure directory
     # + uriParameters - Map of the optional URI parameters record
-    # + return -  If success, FileList record with Details and the marker. Else an error
+    # + return - If success, FileList record with Details and the marker. Else an error
     @display {label: "Get File List"}
-    remote isolated function getFileList(@display {label: "File Share Name"} string fileShareName, 
-                                         @display {label: "Azure Directory Path"} string? azureDirectoryPath = (), 
-                                         @display {label: "Optional URI Parameters"} GetFileListURIParameters 
-                                         uriParameters = {}) returns @display {label: "Response"} FileList|
-                                         error {
-        string requestPath = azureDirectoryPath is () ? (SLASH + fileShareName + SLASH + LIST_FILES_DIRECTORIES_PATH) 
+    remote isolated function getFileList(@display {label: "File Share Name"} string fileShareName,
+                                        @display {label: "Azure Directory Path"} string? azureDirectoryPath = (),
+                                        @display {label: "Optional URI Parameters"} GetFileListURIParameters
+                                        uriParameters = {}) returns @display {label: "Response"} FileList|
+                                        error {
+        string requestPath = azureDirectoryPath is () ? (SLASH + fileShareName + SLASH + LIST_FILES_DIRECTORIES_PATH)
             : (SLASH + fileShareName + SLASH + azureDirectoryPath + SLASH + LIST_FILES_DIRECTORIES_PATH);
         string? optionalURIParameters = setOptionalURIParametersFromRecord(uriParameters);
         requestPath = optionalURIParameters is () ? requestPath : (requestPath + optionalURIParameters);
@@ -108,9 +108,9 @@ public isolated client class FileClient {
             map<string> requiredURIParameters = {};
             requiredURIParameters[RESTYPE] = DIRECTORY;
             requiredURIParameters[COMP] = LIST;
-            string resourcePathForSharedkeyAuth = azureDirectoryPath is () ? (fileShareName + SLASH) 
+            string resourcePathForSharedkeyAuth = azureDirectoryPath is () ? (fileShareName + SLASH)
                 : (fileShareName + SLASH + azureDirectoryPath + SLASH);
-            AuthorizationDetail  authorizationDetail = {
+            AuthorizationDetail authorizationDetail = {
                 azureRequest: request,
                 azureConfig: self.azureConfig,
                 httpVerb: http:HTTP_GET,
@@ -118,9 +118,9 @@ public isolated client class FileClient {
                 resourcePath: resourcePathForSharedkeyAuth,
                 requiredURIParameters: requiredURIParameters
             };
-            check prepareAuthorizationHeaders(authorizationDetail);        
+            check prepareAuthorizationHeaders(authorizationDetail);
         } else {
-            requestPath = requestPath.concat(AMPERSAND, self.azureConfig.accessKeyOrSAS.substring(1)); 
+            requestPath = requestPath.concat(AMPERSAND, self.azureConfig.accessKeyOrSAS.substring(1));
         }
         map<string> headerMap = populateHeaderMapFromRequest(request);
         http:Response response = check self.httpClient->get(requestPath, headerMap);
@@ -140,10 +140,10 @@ public isolated client class FileClient {
     # + azureDirectoryPath - Path to the new directory
     # + return - If success true. Else an error
     @display {label: "Create Directory"}
-    remote isolated function createDirectory(@display {label: "File Share Name"} string fileShareName, 
-                                             @display {label: "New Directory Name"} string newDirectoryName, 
-                                             @display {label: "Azure Directory Path"} string? azureDirectoryPath = ()) 
-                                             returns @display {label: "Response"} error? {
+    remote isolated function createDirectory(@display {label: "File Share Name"} string fileShareName,
+                                            @display {label: "New Directory Name"} string newDirectoryName,
+                                            @display {label: "Azure Directory Path"} string? azureDirectoryPath = ())
+                                            returns @display {label: "Response"} error? {
         string requestPath = SLASH + fileShareName;
         requestPath = azureDirectoryPath is () ? requestPath : (requestPath + SLASH + azureDirectoryPath);
         requestPath = requestPath + SLASH + newDirectoryName + CREATE_DELETE_DIRECTORY_PATH;
@@ -156,20 +156,20 @@ public isolated client class FileClient {
         };
         setSpecificRequestHeaders(request, requiredHeaders);
         if (self.azureConfig.authorizationMethod == ACCESS_KEY) {
-            map<string> requiredURIParameters = {}; 
+            map<string> requiredURIParameters = {};
             requiredURIParameters[RESTYPE] = DIRECTORY;
-            string resourcePathForSharedkeyAuth = azureDirectoryPath is () ? (fileShareName + SLASH + newDirectoryName) 
+            string resourcePathForSharedkeyAuth = azureDirectoryPath is () ? (fileShareName + SLASH + newDirectoryName)
                 : (fileShareName + SLASH + azureDirectoryPath + SLASH + newDirectoryName);
-            AuthorizationDetail  authorizationDetail = {
+            AuthorizationDetail authorizationDetail = {
                 azureRequest: request,
                 azureConfig: self.azureConfig,
                 httpVerb: http:HTTP_PUT,
                 resourcePath: resourcePathForSharedkeyAuth,
                 requiredURIParameters: requiredURIParameters
             };
-            check prepareAuthorizationHeaders(authorizationDetail);       
+            check prepareAuthorizationHeaders(authorizationDetail);
         } else {
-            requestPath = requestPath.concat(AMPERSAND, self.azureConfig.accessKeyOrSAS.substring(1)); 
+            requestPath = requestPath.concat(AMPERSAND, self.azureConfig.accessKeyOrSAS.substring(1));
         }
         http:Response response = check self.httpClient->put(requestPath, request);
         if (response.statusCode != http:STATUS_CREATED) {
@@ -184,29 +184,29 @@ public isolated client class FileClient {
     # + azureDirectoryPath - Path of the Azure directory
     # + return - If success true. Else an error
     @display {label: "Delete Directory"}
-    remote isolated function deleteDirectory(@display {label: "File Share Name"} string fileShareName, 
-                                             @display {label: "Directory Name"} string directoryName, 
-                                             @display {label: "Azure Directory Path"} string? azureDirectoryPath = ()) 
-                                             returns @display {label: "Response"} error? {
+    remote isolated function deleteDirectory(@display {label: "File Share Name"} string fileShareName,
+                                            @display {label: "Directory Name"} string directoryName,
+                                            @display {label: "Azure Directory Path"} string? azureDirectoryPath = ())
+                                            returns @display {label: "Response"} error? {
         string requestPath = SLASH + fileShareName;
         requestPath = azureDirectoryPath is () ? requestPath : (requestPath + SLASH + azureDirectoryPath);
         requestPath = requestPath + SLASH + directoryName + CREATE_DELETE_DIRECTORY_PATH;
         http:Request request = new;
         if (self.azureConfig.authorizationMethod == ACCESS_KEY) {
-            map<string> requiredURIParameters = {}; 
+            map<string> requiredURIParameters = {};
             requiredURIParameters[RESTYPE] = DIRECTORY;
-            string resourcePathForSharedkeyAuth = azureDirectoryPath is () ? (fileShareName + SLASH + directoryName) 
+            string resourcePathForSharedkeyAuth = azureDirectoryPath is () ? (fileShareName + SLASH + directoryName)
                 : (fileShareName + SLASH + azureDirectoryPath + SLASH + directoryName);
-            AuthorizationDetail  authorizationDetail = {
+            AuthorizationDetail authorizationDetail = {
                 azureRequest: request,
                 azureConfig: self.azureConfig,
                 httpVerb: http:HTTP_DELETE,
                 resourcePath: resourcePathForSharedkeyAuth,
                 requiredURIParameters: requiredURIParameters
             };
-            check prepareAuthorizationHeaders(authorizationDetail);       
+            check prepareAuthorizationHeaders(authorizationDetail);
         } else {
-            requestPath = requestPath.concat(AMPERSAND, self.azureConfig.accessKeyOrSAS.substring(1)); 
+            requestPath = requestPath.concat(AMPERSAND, self.azureConfig.accessKeyOrSAS.substring(1));
         }
         http:Response response = check self.httpClient->delete(requestPath, request);
         if (response.statusCode != http:STATUS_ACCEPTED) {
@@ -223,12 +223,12 @@ public isolated client class FileClient {
     # + azureDirectoryPath - Path of the Azure directory 
     # + return - If success true. Else an error
     @display {label: "Create File"}
-    remote isolated function createFile(@display {label: "File Share Name"} string fileShareName, 
-                                        @display {label: "Azure File Name"} string newFileName, 
-                                        @display {label: "File Size"} int fileSizeInByte, 
-                                        @display {label: "Azure Directory Path"} string? azureDirectoryPath = ()) 
+    remote isolated function createFile(@display {label: "File Share Name"} string fileShareName,
+                                        @display {label: "Azure File Name"} string newFileName,
+                                        @display {label: "File Size"} int fileSizeInByte,
+                                        @display {label: "Azure Directory Path"} string? azureDirectoryPath = ())
                                         returns @display {label: "Response"} error? {
-        return createFileInternal(self.httpClient, fileShareName, newFileName, fileSizeInByte, self.azureConfig, 
+        return createFileInternal(self.httpClient, fileShareName, newFileName, fileSizeInByte, self.azureConfig,
             azureDirectoryPath);
     }
 
@@ -241,13 +241,13 @@ public isolated client class FileClient {
     # + return - If successful, File Metadata. Else an Error
     @display {label: "Get File Metadata"}
     remote isolated function getFileMetadata(@display {label: "File Share Name"} string fileShareName,
-                                             @display {label: "File Name"} string fileName, 
-                                             @display {label: "Azure Directory Path"}string? azureDirectoryPath = (),
-                                             @display {label: "Optional Parameters"} OptionalURIParametersFileMetaData
-                                             uriParameters = {}) returns @display {label: "File metadata"} 
-                                             FileMetadataResult|error {
-        string requestPath = azureDirectoryPath is () ? (SLASH + fileShareName + SLASH + fileName + 
-            GET_FILE_METADATA) : SLASH + fileShareName + SLASH + azureDirectoryPath + SLASH 
+                                            @display {label: "File Name"} string fileName,
+                                            @display {label: "Azure Directory Path"} string? azureDirectoryPath = (),
+                                            @display {label: "Optional Parameters"} OptionalURIParametersFileMetaData
+                                            uriParameters = {}) returns @display {label: "File metadata"}
+                                            FileMetadataResult|error {
+        string requestPath = azureDirectoryPath is () ? (SLASH + fileShareName + SLASH + fileName +
+            GET_FILE_METADATA) : SLASH + fileShareName + SLASH + azureDirectoryPath + SLASH
             + fileName + GET_FILE_METADATA;
         string? optionalURIParameters = setOptionalURIParametersFromRecord(uriParameters);
         requestPath = optionalURIParameters is () ? requestPath : (requestPath + optionalURIParameters);
@@ -255,9 +255,9 @@ public isolated client class FileClient {
         if (self.azureConfig.authorizationMethod == ACCESS_KEY) {
             map<string> requiredURIParameters = {};
             requiredURIParameters[COMP] = METADATA;
-            string resourcePathForSharedkeyAuth = azureDirectoryPath is () ? (fileShareName + SLASH + fileName) 
+            string resourcePathForSharedkeyAuth = azureDirectoryPath is () ? (fileShareName + SLASH + fileName)
                 : (fileShareName + SLASH + azureDirectoryPath + SLASH + fileName);
-            AuthorizationDetail  authorizationDetail = {
+            AuthorizationDetail authorizationDetail = {
                 azureRequest:request,
                 azureConfig:self.azureConfig,
                 httpVerb: http:HTTP_GET,
@@ -265,9 +265,9 @@ public isolated client class FileClient {
                 resourcePath: resourcePathForSharedkeyAuth,
                 requiredURIParameters: requiredURIParameters
             };
-            check prepareAuthorizationHeaders(authorizationDetail);       
+            check prepareAuthorizationHeaders(authorizationDetail);
         } else {
-            requestPath = requestPath.concat(AMPERSAND, self.azureConfig.accessKeyOrSAS.substring(1)); 
+            requestPath = requestPath.concat(AMPERSAND, self.azureConfig.accessKeyOrSAS.substring(1));
         }
         map<string> headerMap = populateHeaderMapFromRequest(request);
         http:Response response = check self.httpClient->get(requestPath, headerMap);
@@ -283,13 +283,13 @@ public isolated client class FileClient {
     # + return - If success true. Else an error
     @display {label: "Write Content To Azure File"}
     isolated remote function putRange(@display {label: "File Share Name"} string fileShareName,
-                             @display {label: "Local File Path"} string localFilePath, 
-                             @display {label: "Azure File Name"} string azureFileName, 
-                             @display {label: "Azure Directory Path"} string? azureDirectoryPath = ()) 
-                             returns @display {label: "Status"} error? {
+                            @display {label: "Local File Path"} string localFilePath,
+                            @display {label: "Azure File Name"} string azureFileName,
+                            @display {label: "Azure Directory Path"} string? azureDirectoryPath = ())
+                            returns @display {label: "Status"} error? {
         file:MetaData fileMetaData = check file:getMetaData(localFilePath);
         int fileSizeInByte = fileMetaData.size;
-        return check putRangeInternal(self.httpClient, fileShareName, localFilePath, azureFileName, self.azureConfig, 
+        return check putRangeInternal(self.httpClient, fileShareName, localFilePath, azureFileName, self.azureConfig,
             fileSizeInByte, azureDirectoryPath);
     }
 
@@ -300,29 +300,29 @@ public isolated client class FileClient {
     # + azureDirectoryPath - Path of the Azure directory
     # + return - If success RangeList record. Else an error
     @display {label: "Get List Of Valid Ranges"}
-    remote isolated function listRange(@display {label: "File Share Name"} string fileShareName, 
-                                       @display {label: "Azure File Name"} string fileName, 
-                                       @display {label: "Azure Directory Path"} string? azureDirectoryPath = ()) 
-                                       returns @display {label: "Response"} RangeList|error {
-        string requestPath = azureDirectoryPath is () ? (SLASH + fileShareName + SLASH + fileName + QUESTION_MARK 
-            + LIST_FILE_RANGE) : (SLASH + fileShareName + SLASH + azureDirectoryPath + SLASH + fileName + QUESTION_MARK 
+    remote isolated function listRange(@display {label: "File Share Name"} string fileShareName,
+                                        @display {label: "Azure File Name"} string fileName,
+                                        @display {label: "Azure Directory Path"} string? azureDirectoryPath = ())
+                                        returns @display {label: "Response"} RangeList|error {
+        string requestPath = azureDirectoryPath is () ? (SLASH + fileShareName + SLASH + fileName + QUESTION_MARK
+            + LIST_FILE_RANGE) : (SLASH + fileShareName + SLASH + azureDirectoryPath + SLASH + fileName + QUESTION_MARK
             + LIST_FILE_RANGE);
-        http:Request request = new();
+        http:Request request = new ();
         if (self.azureConfig.authorizationMethod == ACCESS_KEY) {
-            map<string> requiredURIParameters = {}; 
+            map<string> requiredURIParameters = {};
             requiredURIParameters[COMP] = RANGE_LIST;
-            string resourcePathForSharedkeyAuth = azureDirectoryPath is () ? (fileShareName + SLASH + fileName) 
+            string resourcePathForSharedkeyAuth = azureDirectoryPath is () ? (fileShareName + SLASH + fileName)
                 : (fileShareName + SLASH + azureDirectoryPath + SLASH + fileName);
-            AuthorizationDetail  authorizationDetail = {
+            AuthorizationDetail authorizationDetail = {
                 azureRequest: request,
                 azureConfig: self.azureConfig,
                 httpVerb: http:HTTP_GET,
                 resourcePath: resourcePathForSharedkeyAuth,
                 requiredURIParameters: requiredURIParameters
             };
-            check prepareAuthorizationHeaders(authorizationDetail);     
+            check prepareAuthorizationHeaders(authorizationDetail);
         } else {
-            requestPath = requestPath.concat(AMPERSAND, self.azureConfig.accessKeyOrSAS.substring(1)); 
+            requestPath = requestPath.concat(AMPERSAND, self.azureConfig.accessKeyOrSAS.substring(1));
         }
         map<string> headerMap = populateHeaderMapFromRequest(request);
         http:Response response = check self.httpClient->get(requestPath, headerMap);
@@ -341,28 +341,28 @@ public isolated client class FileClient {
     # + azureDirectoryPath - Path of the Azure directory
     # + return - If success true. Else an error
     @display {label: "Delete File"}
-    remote isolated function deleteFile(@display {label: "File Share Name"} string fileShareName, 
-                                        @display {label: "Azure File Name"} string fileName, 
-                                        @display {label: "Azure Directory Path"} string? azureDirectoryPath = ()) 
+    remote isolated function deleteFile(@display {label: "File Share Name"} string fileShareName,
+                                        @display {label: "Azure File Name"} string fileName,
+                                        @display {label: "Azure Directory Path"} string? azureDirectoryPath = ())
                                         returns @display {label: "Response"} error? {
         http:Request request = new;
         string requestPath = SLASH + fileShareName;
         requestPath = azureDirectoryPath is () ? requestPath : (requestPath + SLASH + azureDirectoryPath);
         requestPath = requestPath + SLASH + fileName;
         if (self.azureConfig.authorizationMethod == ACCESS_KEY) {
-            map<string> requiredURIParameters = {}; 
-            string resourcePathForSharedkeyAuth = azureDirectoryPath is () ? (fileShareName + SLASH + fileName) 
+            map<string> requiredURIParameters = {};
+            string resourcePathForSharedkeyAuth = azureDirectoryPath is () ? (fileShareName + SLASH + fileName)
                 : (fileShareName + SLASH + azureDirectoryPath + SLASH + fileName);
-            AuthorizationDetail  authorizationDetail = {
+            AuthorizationDetail authorizationDetail = {
                 azureRequest: request,
                 azureConfig: self.azureConfig,
                 httpVerb: http:HTTP_DELETE,
                 resourcePath: resourcePathForSharedkeyAuth,
                 requiredURIParameters: requiredURIParameters
             };
-            check prepareAuthorizationHeaders(authorizationDetail);      
+            check prepareAuthorizationHeaders(authorizationDetail);
         } else {
-            requestPath = requestPath.concat(QUESTION_MARK, self.azureConfig.accessKeyOrSAS.substring(1)); 
+            requestPath = requestPath.concat(QUESTION_MARK, self.azureConfig.accessKeyOrSAS.substring(1));
         }
         http:Response response = check self.httpClient->delete(requestPath, request);
         if (response.statusCode != http:STATUS_ACCEPTED) {
@@ -376,30 +376,30 @@ public isolated client class FileClient {
     # + fileName - Name of the file
     # + azureDirectoryPath - Path of azure directory
     # + localFilePath - Path to the local destination location
-    # + return -  If success true. Else an error
+    # + return - If success true. Else an error
     @display {label: "Download File"}
-    remote isolated function getFile(@display {label: "File Share Name"} string fileShareName, 
-                                     @display {label: "Azure File Name"} string fileName, 
-                                     @display {label: "Download Location"} string localFilePath, 
-                                     @display {label: "Azure Directory Path"} string? azureDirectoryPath = ()) 
-                                     returns @display {label: "Response"} error? {
-        string requestPath = azureDirectoryPath is () ? (SLASH + fileShareName + SLASH + fileName) : (SLASH 
-            + fileShareName + SLASH + azureDirectoryPath + SLASH + fileName);    
+    remote isolated function getFile(@display {label: "File Share Name"} string fileShareName,
+                                    @display {label: "Azure File Name"} string fileName,
+                                    @display {label: "Download Location"} string localFilePath,
+                                    @display {label: "Azure Directory Path"} string? azureDirectoryPath = ())
+                                    returns @display {label: "Response"} error? {
+        string requestPath = azureDirectoryPath is () ? (SLASH + fileShareName + SLASH + fileName) : (SLASH
+            + fileShareName + SLASH + azureDirectoryPath + SLASH + fileName);
         http:Request request = new;
         if (self.azureConfig.authorizationMethod == ACCESS_KEY) {
-            map<string> requiredURIParameters = {}; 
-            string resourcePathForSharedkeyAuth = azureDirectoryPath is () ? (fileShareName + SLASH + fileName) 
+            map<string> requiredURIParameters = {};
+            string resourcePathForSharedkeyAuth = azureDirectoryPath is () ? (fileShareName + SLASH + fileName)
                 : (fileShareName + SLASH + azureDirectoryPath + SLASH + fileName);
-            AuthorizationDetail  authorizationDetail = {
+            AuthorizationDetail authorizationDetail = {
                 azureRequest: request,
                 azureConfig: self.azureConfig,
                 httpVerb: http:HTTP_GET,
                 resourcePath: resourcePathForSharedkeyAuth,
                 requiredURIParameters: requiredURIParameters
             };
-            check prepareAuthorizationHeaders(authorizationDetail);      
+            check prepareAuthorizationHeaders(authorizationDetail);
         } else {
-            requestPath = requestPath.concat(QUESTION_MARK, self.azureConfig.accessKeyOrSAS.substring(1)); 
+            requestPath = requestPath.concat(QUESTION_MARK, self.azureConfig.accessKeyOrSAS.substring(1));
         }
         map<string> headerMap = populateHeaderMapFromRequest(request);
         http:Response response = check self.httpClient->get(requestPath, headerMap);
@@ -407,40 +407,51 @@ public isolated client class FileClient {
         check writeFile(localFilePath, responseBody);
     }
 
-
     # Downloads a file from fileshare to a specified location as an Byte array
     #
-    # + fileShareName - Name of the FileShare
-    # + fileName - Name of the file
-    # + azureDirectoryPath - Path of azure directory
-    # + return -  If successful, file content as a byte array. Else an error
+    # + fileShareName - Name of the FileShare  
+    # + fileName - Name of the file  
+    # + azureDirectoryPath - Path of azure directory  
+    # + range - The specified byte range to be returned the file data 
+    # + return - If successful, file content as a byte array. Else an error
     @display {label: "Download File"}
-    remote isolated function getFileAsByteArray(@display {label: "File Share Name"} string fileShareName, 
-                                     @display {label: "Azure File Name"} string fileName,  
-                                     @display {label: "Azure Directory Path"} string? azureDirectoryPath = ()) 
-                                     returns @display {label: "Response"} byte[]|error {
-        string requestPath = azureDirectoryPath is () ? (SLASH + fileShareName + SLASH + fileName) : (SLASH 
-            + fileShareName + SLASH + azureDirectoryPath + SLASH + fileName);    
+    remote isolated function getFileAsByteArray(@display {label: "File Share Name"} string fileShareName,
+                                    @display {label: "Azure File Name"} string fileName,
+                                    @display {label: "Azure Directory Path"} string? azureDirectoryPath = (),
+                                    @display {label: "Byte Range"} ContentRange? range = ())
+                                    returns @display {label: "Response"} byte[]|error {
+        string requestPath = azureDirectoryPath is () ? (SLASH + fileShareName + SLASH + fileName) : (SLASH
+            + fileShareName + SLASH + azureDirectoryPath + SLASH + fileName);
         http:Request request = new;
+        if (range != ()) {
+            string rangeHeader = "bytes=" + range.startByte.toString() + "-" + range.endByte.toString();
+            request.setHeader(X_MS_RANGE, rangeHeader);
+        }
         if (self.azureConfig.authorizationMethod == ACCESS_KEY) {
-            map<string> requiredURIParameters = {}; 
-            string resourcePathForSharedkeyAuth = azureDirectoryPath is () ? (fileShareName + SLASH + fileName) 
+            map<string> requiredURIParameters = {};
+            string resourcePathForSharedkeyAuth = azureDirectoryPath is () ? (fileShareName + SLASH + fileName)
                 : (fileShareName + SLASH + azureDirectoryPath + SLASH + fileName);
-            AuthorizationDetail  authorizationDetail = {
+            AuthorizationDetail authorizationDetail = {
                 azureRequest: request,
                 azureConfig: self.azureConfig,
                 httpVerb: http:HTTP_GET,
                 resourcePath: resourcePathForSharedkeyAuth,
                 requiredURIParameters: requiredURIParameters
             };
-            check prepareAuthorizationHeaders(authorizationDetail);      
+            check prepareAuthorizationHeaders(authorizationDetail);
         } else {
-            requestPath = requestPath.concat(QUESTION_MARK, self.azureConfig.accessKeyOrSAS.substring(1)); 
+            requestPath = requestPath.concat(QUESTION_MARK, self.azureConfig.accessKeyOrSAS.substring(1));
         }
         map<string> headerMap = populateHeaderMapFromRequest(request);
         http:Response response = check self.httpClient->get(requestPath, headerMap);
-        byte[] payload = check response.getBinaryPayload();
-        return payload;
+        boolean isFileTypeAvailable = response.hasHeader(X_MS_TYPE);
+        if (isFileTypeAvailable == true) {
+            byte[] payload = check response.getBinaryPayload();
+            return payload;
+        } else {
+            xml errorMessage = check response.getXmlPayload();
+            fail error(errorMessage.toString());
+        }
     }
 
     # Copies a file to another location in fileShare. 
@@ -451,12 +462,12 @@ public isolated client class FileClient {
     # + destDirectoryPath - Path of the destination in fileShare
     # + return - If success, true. Else an error
     @display {label: "Copy File"}
-    remote isolated function copyFile(@display {label: "File Share Name"} string fileShareName, 
-                                      @display {label: "Source File URL"} string sourceURL, 
-                                      @display {label: "Destination File Name"} string destFileName, 
-                                      @display {label: "Destination Directory Path"} string? destDirectoryPath = ()) 
-                                      returns @display {label: "Response"} error? {
-        string requestPath = destDirectoryPath is () ? (SLASH + fileShareName + SLASH + destFileName) 
+    remote isolated function copyFile(@display {label: "File Share Name"} string fileShareName,
+                                    @display {label: "Source File URL"} string sourceURL,
+                                    @display {label: "Destination File Name"} string destFileName,
+                                    @display {label: "Destination Directory Path"} string? destDirectoryPath = ())
+                                    returns @display {label: "Response"} error? {
+        string requestPath = destDirectoryPath is () ? (SLASH + fileShareName + SLASH + destFileName)
             : (SLASH + fileShareName + SLASH + destDirectoryPath + SLASH + destFileName);
         string sourcePath = sourceURL;
         if (self.azureConfig.authorizationMethod == SAS) {
@@ -466,19 +477,19 @@ public isolated client class FileClient {
         map<string> requiredSpecificHeaderes = {[X_MS_COPY_SOURCE]: sourcePath};
         setSpecificRequestHeaders(request, requiredSpecificHeaderes);
         if (self.azureConfig.authorizationMethod == ACCESS_KEY) {
-            map<string> requiredURIParameters = {}; 
-            string resourcePathForSharedkeyAuth = destDirectoryPath is () ? (fileShareName + SLASH + destFileName) 
+            map<string> requiredURIParameters = {};
+            string resourcePathForSharedkeyAuth = destDirectoryPath is () ? (fileShareName + SLASH + destFileName)
                 : (fileShareName + SLASH + destDirectoryPath + SLASH + destFileName);
-            AuthorizationDetail  authorizationDetail = {
+            AuthorizationDetail authorizationDetail = {
                 azureRequest: request,
                 azureConfig: self.azureConfig,
                 httpVerb: http:HTTP_PUT,
                 resourcePath: resourcePathForSharedkeyAuth,
                 requiredURIParameters: requiredURIParameters
             };
-            check prepareAuthorizationHeaders(authorizationDetail);       
+            check prepareAuthorizationHeaders(authorizationDetail);
         } else {
-            requestPath = requestPath.concat(self.azureConfig.accessKeyOrSAS); 
+            requestPath = requestPath.concat(self.azureConfig.accessKeyOrSAS);
         }
         http:Response response = check self.httpClient->put(requestPath, request);
         if (response.statusCode != http:STATUS_ACCEPTED) {
@@ -487,39 +498,39 @@ public isolated client class FileClient {
     }
 
     # Upload a file directly to the fileshare.
-    # 
+    #
     # + fileShareName - Name of the fileShare
     # + localFilePath - The path of the file to be uploaded
     # + azureFileName - The name of the file in Azure
     # + azureDirectoryPath - Directory path in Azure
     # + return - If success true. Else an error
-    isolated remote function directUpload(@display {label: "File Share Name"} string fileShareName, 
-                                 @display {label: "Local File Path"} string localFilePath, 
-                                 @display {label: "Azure File Name"} string azureFileName, 
-                                 @display {label: "Azure Directory Path"} string? azureDirectoryPath = ()) 
-                                 returns @display {label: "Response"} error? {
+    isolated remote function directUpload(@display {label: "File Share Name"} string fileShareName,
+                                @display {label: "Local File Path"} string localFilePath,
+                                @display {label: "Azure File Name"} string azureFileName,
+                                @display {label: "Azure Directory Path"} string? azureDirectoryPath = ())
+                                returns @display {label: "Response"} error? {
         file:MetaData fileMetaData = check file:getMetaData(localFilePath);
         int fileSizeInByte = fileMetaData.size;
         check self->createFile(fileShareName, azureFileName, fileSizeInByte, azureDirectoryPath);
-        check putRangeInternal(self.httpClient, fileShareName, localFilePath, azureFileName, 
+        check putRangeInternal(self.httpClient, fileShareName, localFilePath, azureFileName,
                             self.azureConfig, fileSizeInByte, azureDirectoryPath);
     }
 
     # Uploads a byte array directly to the fileshare.
-    # 
+    #
     # + fileShareName - Name of the fileShare
     # + fileContent - File content as a byte array
     # + azureFileName - Name of the file in Azure
     # + azureDirectoryPath - Directory path in Azure
     # + return - If success true.  Else an error
-    isolated remote function directUploadFileAsByteArray(@display {label: "File Share Name"} string fileShareName, 
-                                 @display {label: "File Content (Byte Array)"} byte[] fileContent, 
-                                 @display {label: "Azure File Name"} string azureFileName, 
-                                 @display {label: "Azure Directory Path"} string? azureDirectoryPath = ()) 
-                                 returns @display {label: "Response"} error? {
-        int fileSizeInByte = fileContent.length();                      
+    isolated remote function directUploadFileAsByteArray(@display {label: "File Share Name"} string fileShareName,
+                                @display {label: "File Content (Byte Array)"} byte[] fileContent,
+                                @display {label: "Azure File Name"} string azureFileName,
+                                @display {label: "Azure Directory Path"} string? azureDirectoryPath = ())
+                                returns @display {label: "Response"} error? {
+        int fileSizeInByte = fileContent.length();
         check self->createFile(fileShareName, azureFileName, fileSizeInByte, azureDirectoryPath);
-        check putRangeAsByteArray(self.httpClient, fileShareName,fileContent, azureFileName, 
+        check putRangeAsByteArray(self.httpClient, fileShareName, fileContent, azureFileName,
                             self.azureConfig, fileSizeInByte, azureDirectoryPath);
     }
 }

--- a/storageservice/modules/files/records.bal
+++ b/storageservice/modules/files/records.bal
@@ -335,6 +335,15 @@ public type OptionalURIParametersFileMetaData record {|
     string timeout?;
 |};
 
+# Defines byte range of a file content
+#
+# + startByte - Start position, Example: 0  
+# + endByte - End position, Example: 255
+public type ContentRange record {|
+    int startByte;
+    int endByte;
+|};
+
 # Represents File Metadata Result.
 #
 # + metadata - Metadata of file


### PR DESCRIPTION
# Description

Adding response content type validation to the operation `getFileAsByteArray`;
Adding support for specific byte range downloadings

Fixes https://github.com/ballerina-platform/ballerina-extended-library/issues/326

One line release note: 
- Adding response content type validation to the operation `getFileAsByteArray` and support for byte-range downloads

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- All tests passed

**Test Configuration**:
* Ballerina Version: Swan Lake 2201.0.2
* Operating System:
* Java SDK: 11

# Checklist:

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
