### PR TITLE
Update error handling with proper error subtypes

### DIFF
--- a/storageservice/Ballerina.toml
+++ b/storageservice/Ballerina.toml
@@ -1,8 +1,8 @@
 [package]
-distribution = "2201.3.0"
+distribution = "2201.3.2"
 org = "ballerinax"
 name = "azure_storage_service"
-version = "4.0.1"
+version = "4.1.0"
 authors = ["Ballerina"]
 export = ["azure_storage_service", "azure_storage_service.files", "azure_storage_service.blobs"]
 keywords = ["Content & Files/File Management & Storage", "Cost/Paid", "Vendor/Microsoft"]

--- a/storageservice/modules/blobs/management_client.bal
+++ b/storageservice/modules/blobs/management_client.bal
@@ -15,7 +15,6 @@
 // under the License.
 
 import ballerina/http;
-import ballerina/xmldata;
 import ballerinax/'client.config;
 
 # Azure Storage Blob Management Client Object.
@@ -24,7 +23,7 @@ import ballerinax/'client.config;
 # + accessKeyOrSAS - Access Key or Shared Access Signature for the Azure Storage Account
 # + accountName - Azure Storage Account Name
 # + authorizationMethod - If authorization method is accessKey or SAS
-# 
+#
 @display {label: "Azure Storage Blob Management", iconPath: "storageservice/icon.png"}
 public isolated client class ManagementClient {
     private final http:Client httpClient;
@@ -32,14 +31,18 @@ public isolated client class ManagementClient {
     private final string accessKeyOrSAS;
     private final AuthorizationMethod authorizationMethod;
 
-    public isolated function init(ConnectionConfig config) returns error? {
-        string baseURL = string `https://${config.accountName}.blob.core.windows.net`;
-        http:ClientConfiguration httpClientConfig = check config:constructHTTPClientConfig(config);
-        httpClientConfig.http1Settings = {chunking: http:CHUNKING_NEVER};
-        self.httpClient = check new (baseURL, httpClientConfig);
-        self.accessKeyOrSAS = config.accessKeyOrSAS;
-        self.accountName = config.accountName;
-        self.authorizationMethod = config.authorizationMethod;
+    public isolated function init(ConnectionConfig config) returns Error? {
+        do {
+            string baseURL = string `https://${config.accountName}.blob.core.windows.net`;
+            http:ClientConfiguration httpClientConfig = check config:constructHTTPClientConfig(config);
+            httpClientConfig.http1Settings = {chunking: http:CHUNKING_NEVER};
+            self.httpClient = check new (baseURL, httpClientConfig);
+            self.accessKeyOrSAS = config.accessKeyOrSAS;
+            self.accountName = config.accountName;
+            self.authorizationMethod = config.authorizationMethod;
+        } on fail error e {
+            return error ProcessingError("Error while constructing HTTP Client Config", e);
+        }
     }
 
     # Get Account Information of the azure storage account.
@@ -48,30 +51,30 @@ public isolated client class ManagementClient {
     # the analytics logs when storage analytics logging is enabled. 
     # + return - If successful, returns AccountInformation. Else returns Error. 
     @display {label: "Get Account Info"}
-    remote isolated function getAccountInformation(string? clientRequestId = ()) returns @display {label: "Account information"} 
-            AccountInformationResult|error {                 
+    remote isolated function getAccountInformation(string? clientRequestId = ()) returns @display {label: "Account information"}
+            AccountInformationResult|Error {
         http:Request request = new;
-        check setDefaultHeaders(request);
+        setDefaultHeaders(request);
         map<string> uriParameterMap = {};
         uriParameterMap[RESTYPE] = ACCOUNT;
         uriParameterMap[COMP] = PROPERTIES;
         setOptionalHeaders(request, clientRequestId);
-        
-        if (self.authorizationMethod ==ACCESS_KEY) {
-            check addAuthorizationHeader(request, http:HTTP_GET, self.accountName, self.accessKeyOrSAS, EMPTY_STRING, 
+
+        if (self.authorizationMethod == ACCESS_KEY) {
+            check addAuthorizationHeader(request, http:HTTP_GET, self.accountName, self.accessKeyOrSAS, EMPTY_STRING,
                 uriParameterMap);
         }
-        
+
         string resourcePath = FORWARD_SLASH_SYMBOL;
-        string path = preparePath(self.authorizationMethod, self.accessKeyOrSAS, uriParameterMap, resourcePath);  
+        string path = preparePath(self.authorizationMethod, self.accessKeyOrSAS, uriParameterMap, resourcePath);
         map<string> headerMap = populateHeaderMapFromRequest(request);
-        http:Response response = <http:Response> check self.httpClient->get(path, headerMap);
+        http:Response response = <http:Response>check self.httpClient->get(path, headerMap);
         check checkAndHandleErrors(response);
         return convertResponseToAccountInformationType(response);
     }
 
     # Create a container in the azure storage account.
-    # 
+    #
     # + containerName - Name of the container
     # + metadata - A name-value pair to associate with the container as metadata
     # + accessLevel - Specifies whether data in the container can be accessed publicly and the level of access
@@ -79,87 +82,87 @@ public isolated client class ManagementClient {
     # the analytics logs when storage analytics logging is enabled. 
     # + return - If successful, returns Response. Else returns Error. 
     @display {label: "Create Container"}
-    remote isolated function createContainer (@display {label: "Container Name"} string containerName, 
-    AccessLevel? accessLevel = (), map<string>? metadata = (), string? clientRequestId = ()) returns 
-    @display {label: "Response"} map<json>|error {
+    remote isolated function createContainer(@display {label: "Container Name"} string containerName,
+            AccessLevel? accessLevel = (), map<string>? metadata = (), string? clientRequestId = ()) returns
+    @display {label: "Response"} map<json>|Error {
         http:Request request = new;
-        check setDefaultHeaders(request);
+        setDefaultHeaders(request);
         map<string> uriParameterMap = {};
         uriParameterMap[RESTYPE] = CONTAINER;
         setOptionalHeaders(request, clientRequestId, accessLevel = accessLevel, metadata = metadata);
 
-        if (self.authorizationMethod ==ACCESS_KEY) {
-            check addAuthorizationHeader(request, http:HTTP_PUT, self.accountName, self.accessKeyOrSAS, containerName, 
+        if (self.authorizationMethod == ACCESS_KEY) {
+            check addAuthorizationHeader(request, http:HTTP_PUT, self.accountName, self.accessKeyOrSAS, containerName,
                 uriParameterMap);
         }
 
         string resourcePath = FORWARD_SLASH_SYMBOL + containerName;
         string path = preparePath(self.authorizationMethod, self.accessKeyOrSAS, uriParameterMap, resourcePath);
-        http:Response response = <http:Response> check self.httpClient->put(path, request);
+        http:Response response = <http:Response>check self.httpClient->put(path, request);
         _ = check handleResponse(response);
         return getHeaderMapFromResponse(response);
     }
 
     # Delete a container from the azure storage account.
-    # 
+    #
     # + containerName - Name of the container
     # + clientRequestId - Provides a client-generated, opaque value with a 1 KiB character limit that is recorded in 
     # the analytics logs when storage analytics logging is enabled. 
     # + leaseId - If the container has an active lease
     # + return - If successful, returns Response. Else returns Error. 
     @display {label: "Delete Container"}
-    remote isolated function deleteContainer (@display {label: "Container Name"} string containerName,
-    string? clientRequestId = (), string? leaseId = ()) returns @display {label: "Response"} map<json>|error {
+    remote isolated function deleteContainer(@display {label: "Container Name"} string containerName,
+            string? clientRequestId = (), string? leaseId = ()) returns @display {label: "Response"} map<json>|Error {
         http:Request request = new;
-        check setDefaultHeaders(request);
+        setDefaultHeaders(request);
         map<string> uriParameterMap = {};
         uriParameterMap[RESTYPE] = CONTAINER;
         setOptionalHeaders(request, clientRequestId, leaseId);
 
-        if (self.authorizationMethod ==ACCESS_KEY) {
-            check addAuthorizationHeader(request, http:HTTP_DELETE, self.accountName, self.accessKeyOrSAS, containerName, 
+        if (self.authorizationMethod == ACCESS_KEY) {
+            check addAuthorizationHeader(request, http:HTTP_DELETE, self.accountName, self.accessKeyOrSAS, containerName,
                 uriParameterMap);
         }
 
         string resourcePath = FORWARD_SLASH_SYMBOL + containerName;
         string path = preparePath(self.authorizationMethod, self.accessKeyOrSAS, uriParameterMap, resourcePath);
-        http:Response response = <http:Response> check self.httpClient->delete(path, request);
+        http:Response response = <http:Response>check self.httpClient->delete(path, request);
         _ = check handleResponse(response);
         return getHeaderMapFromResponse(response);
     }
 
     # Get Container Properties.
-    # 
+    #
     # + containerName - Name of the container
     # + clientRequestId - Provides a client-generated, opaque value with a 1 KiB character limit that is recorded in 
     # the analytics logs when storage analytics logging is enabled. 
     # + leaseId - If the container has an active lease
     # + return - If successful, returns Container Properties. Else returns Error. 
     @display {label: "Get Container Properties"}
-    remote isolated function getContainerProperties(@display {label: "Container Name"} string containerName, 
-    string? clientRequestId = (), string? leaseId = ()) returns @display {label: "Container properties"} 
-    ContainerPropertiesResult|error {
+    remote isolated function getContainerProperties(@display {label: "Container Name"} string containerName,
+            string? clientRequestId = (), string? leaseId = ()) returns @display {label: "Container properties"}
+    ContainerPropertiesResult|Error {
         http:Request request = new;
-        check setDefaultHeaders(request);
+        setDefaultHeaders(request);
         map<string> uriParameterMap = {};
         uriParameterMap[RESTYPE] = CONTAINER;
-        setOptionalHeaders(request,clientRequestId, leaseId);
+        setOptionalHeaders(request, clientRequestId, leaseId);
 
-        if (self.authorizationMethod ==ACCESS_KEY) {
-            check addAuthorizationHeader(request, http:HTTP_HEAD, self.accountName, self.accessKeyOrSAS, containerName, 
+        if (self.authorizationMethod == ACCESS_KEY) {
+            check addAuthorizationHeader(request, http:HTTP_HEAD, self.accountName, self.accessKeyOrSAS, containerName,
                 uriParameterMap);
         }
 
         string resourcePath = FORWARD_SLASH_SYMBOL + containerName;
         string path = preparePath(self.authorizationMethod, self.accessKeyOrSAS, uriParameterMap, resourcePath);
         map<string> headerMap = populateHeaderMapFromRequest(request);
-        http:Response response = <http:Response> check self.httpClient->head(path, headerMap);
+        http:Response response = <http:Response>check self.httpClient->head(path, headerMap);
         check checkAndHandleErrors(response);
         return convertResponseToContainerPropertiesResult(response);
     }
 
     # Get Container Metadata.
-    # 
+    #
     # + containerName - Name of the container
     # + clientRequestId - Provides a client-generated, opaque value with a 1 KiB character limit that is recorded in 
     # the analytics logs when storage analytics logging is enabled. 
@@ -167,90 +170,90 @@ public isolated client class ManagementClient {
     # + return - If successful, returns Container Metadata. Else returns Error. 
     @display {label: "Container Metadata"}
     remote isolated function getContainerMetadata(@display {label: "Container Name"} string containerName,
-    string? clientRequestId = (), string? leaseId = ()) returns @display {label: "Container metadata"} 
-    ContainerMetadataResult|error {
+            string? clientRequestId = (), string? leaseId = ()) returns @display {label: "Container metadata"}
+    ContainerMetadataResult|Error {
         http:Request request = new;
-        check setDefaultHeaders(request);
+        setDefaultHeaders(request);
         map<string> uriParameterMap = {};
         uriParameterMap[RESTYPE] = CONTAINER;
         uriParameterMap[COMP] = METADATA;
         setOptionalHeaders(request, clientRequestId, leaseId);
 
-        if (self.authorizationMethod ==ACCESS_KEY) {
-            check addAuthorizationHeader(request, http:HTTP_GET, self.accountName, self.accessKeyOrSAS, containerName, 
+        if (self.authorizationMethod == ACCESS_KEY) {
+            check addAuthorizationHeader(request, http:HTTP_GET, self.accountName, self.accessKeyOrSAS, containerName,
                 uriParameterMap);
-        } 
-        
+        }
+
         string resourcePath = FORWARD_SLASH_SYMBOL + containerName;
         string path = preparePath(self.authorizationMethod, self.accessKeyOrSAS, uriParameterMap, resourcePath);
         map<string> headerMap = populateHeaderMapFromRequest(request);
-        http:Response response = <http:Response> check self.httpClient->get(path, headerMap);
+        http:Response response = <http:Response>check self.httpClient->get(path, headerMap);
         check checkAndHandleErrors(response);
         return convertResponseToContainerMetadataResult(response);
     }
 
     # Get Container ACL (gets the permissions for the specified container).
-    # 
+    #
     # + containerName - Name of the container
     # + clientRequestId - Provides a client-generated, opaque value with a 1 KiB character limit that is recorded in 
     # the analytics logs when storage analytics logging is enabled. 
     # + leaseId - If the container has an active lease
     # + return - If successful, returns container ACL. Else returns Error. 
     @display {label: "Get Containe ACL"}
-    remote isolated function getContainerACL(@display {label: "Container Name"} string containerName, string? 
-    clientRequestId = (), string? leaseId = ()) returns @display {label: "Container ACL"} ContainerACLResult|error {
-        if (self.authorizationMethod ==ACCESS_KEY ) {
+    remote isolated function getContainerACL(@display {label: "Container Name"} string containerName, string?
+    clientRequestId = (), string? leaseId = ()) returns @display {label: "Container ACL"} ContainerACLResult|Error {
+        if (self.authorizationMethod == ACCESS_KEY) {
             http:Request request = new;
-            check setDefaultHeaders(request);
+            setDefaultHeaders(request);
             map<string> uriParameterMap = {};
             uriParameterMap[RESTYPE] = CONTAINER;
             uriParameterMap[COMP] = ACL;
             setOptionalHeaders(request, clientRequestId, leaseId);
 
-            check addAuthorizationHeader(request, http:HTTP_HEAD, self.accountName, self.accessKeyOrSAS, containerName, 
+            check addAuthorizationHeader(request, http:HTTP_HEAD, self.accountName, self.accessKeyOrSAS, containerName,
                 uriParameterMap);
 
             string resourcePath = FORWARD_SLASH_SYMBOL + containerName;
             string path = preparePath(self.authorizationMethod, self.accessKeyOrSAS, uriParameterMap, resourcePath);
             map<string> headerMap = populateHeaderMapFromRequest(request);
-            http:Response response = <http:Response> check self.httpClient->head(path, headerMap);
+            http:Response response = <http:Response>check self.httpClient->head(path, headerMap);
             check checkAndHandleErrors(response);
             return convertResponseToContainerACLResult(response);
         } else {
             return error(AZURE_BLOB_ERROR_CODE, message = ("This operation is supported only with accessKey "
                 + "Authentication"));
-        } 
+        }
     }
 
     # Get Blob Service Properties.
-    # 
+    #
     # + clientRequestId - Provides a client-generated, opaque value with a 1 KiB character limit that is recorded in 
     # the analytics logs when storage analytics logging is enabled. 
     # + return - If successful, returns Blob Service Properties. Else returns Error. 
     @display {label: "Get Blob Service Properties"}
-    remote isolated function getBlobServiceProperties(string? clientRequestId = ()) returns 
-    @display {label: "Blob service properties"} BlobServicePropertiesResult|error {
+    remote isolated function getBlobServiceProperties(string? clientRequestId = ()) returns
+    @display {label: "Blob service properties"} BlobServicePropertiesResult|Error {
         http:Request request = new;
-        check setDefaultHeaders(request);
+        setDefaultHeaders(request);
         map<string> uriParameterMap = {};
         uriParameterMap[RESTYPE] = SERVICE;
         uriParameterMap[COMP] = PROPERTIES;
         setOptionalHeaders(request, clientRequestId);
 
-        if (self.authorizationMethod ==ACCESS_KEY) {
-            check addAuthorizationHeader(request, http:HTTP_GET, self.accountName, self.accessKeyOrSAS, EMPTY_STRING, 
+        if (self.authorizationMethod == ACCESS_KEY) {
+            check addAuthorizationHeader(request, http:HTTP_GET, self.accountName, self.accessKeyOrSAS, EMPTY_STRING,
                 uriParameterMap);
         }
 
         string resourcePath = FORWARD_SLASH_SYMBOL;
-        string path = preparePath(self.authorizationMethod, self.accessKeyOrSAS, uriParameterMap, resourcePath); 
+        string path = preparePath(self.authorizationMethod, self.accessKeyOrSAS, uriParameterMap, resourcePath);
         map<string> headerMap = populateHeaderMapFromRequest(request);
-        http:Response response = <http:Response> check self.httpClient->get(path, headerMap);
-        xml blobServiceProperties = <xml> check handleResponse(response);
+        http:Response response = <http:Response>check self.httpClient->get(path, headerMap);
+        xml blobServiceProperties = <xml>check handleResponse(response);
         BlobServicePropertiesResult blobServicePropertiesResult = {
-            storageServiceProperties: check xmldata:toJson(blobServiceProperties/*),
+            storageServiceProperties: check convertXMLToJson(blobServiceProperties/*),
             responseHeaders: getHeaderMapFromResponse(response)
         };
         return blobServicePropertiesResult;
-    }  
+    }
 }

--- a/storageservice/modules/blobs/types.bal
+++ b/storageservice/modules/blobs/types.bal
@@ -23,7 +23,7 @@ public type ConnectionConfig record {|
     *config:ConnectionConfig;
     never auth?;
     # Access key or Shared Access Signature for Azure Storage Account 
-    @display{
+    @display {
         label: "",
         kind: "password"
     }
@@ -44,7 +44,7 @@ public type ConnectionConfig record {|
 # + responseHeaders - reponse headers and values related to the operation
 public type AccountInformationResult record {
     string skuName;
-    string accountKind ;
+    string accountKind;
     string isHNSEnabled;
     map<json> responseHeaders;
 };
@@ -79,7 +79,7 @@ public type Blob record {
     string VersionId?;
     string IsCurrentVersion?;
     string Deleted?;
-    
+
 };
 
 # Represents Azure Storage Blob Properties.
@@ -169,11 +169,11 @@ public type Properties record {|
 # + metaData - Meta data of container
 # + responseHeaders - Response headers from Azure
 public type ContainerPropertiesResult record {
-    string eTag ; 
+    string eTag;
     string lastModified;
     string leaseStatus;
     string leaseState;
-    string leaseDuration?; 
+    string leaseDuration?;
     string publicAccess?;
     string hasImmutabilityPolicy;
     string hasLegalHold;
@@ -302,43 +302,46 @@ public enum AccessLevel {
 
 # Defines the details of an error message.
 #
-# + errorCode - Azure Blob Storage error code
+# + httpStatus - HTTP status code associated with the error 
+# + errorCode - Azure Blob Storage error code  
 # + message - Associated error message
-public type BlobErrorDetail record {|
+public type ServerErrorDetail record {|
+    int httpStatus;
     string errorCode;
     string message;
 |};
 
-# Defines the generic error detail optional error code.
-#
-# + httpStatus - HTTP status code
-# + errorCode - Associated error code
-# + message - Associated error message
-public type BlobErrorDetailGeneric record {|
-    int httpStatus;
-    string errorCode?;
-    string message?;
-|};
+# Super type error returned by connector
+public type Error ServerError|ClientError;
 
-# Error created by connector depending on server responses.
-public type BlobError distinct error<BlobErrorDetail>;
+# Error created by connector depending on server responses
+public type ServerError distinct error<ServerErrorDetail>;
 
-# Generic error created by connector depending on server responses.
-public type BlobErrorGeneric distinct error<BlobErrorDetailGeneric>;
+# Error created by connector when processing or invoking
+public type ClientError ProcessingError|http:ClientError;
+
+# Error created by connector when processing, transforming data
+public type ProcessingError distinct error;
 
 # Error types as per https://learn.microsoft.com/en-us/rest/api/storageservices/blob-service-error-codes
 
 # Error for Http Status 412
-public type PreconditionFailedError distinct BlobError;
+public type PreconditionFailedError distinct ServerError;
+
 # Error for Http Status 409
-public type ConflictError distinct BlobError;
+public type ConflictError distinct ServerError;
+
 # Error for Http Status 404
-public type NotFoundError distinct BlobError;
+public type NotFoundError distinct ServerError;
+
 # Error for Http Status 400
-public type BadRequestError distinct BlobError;
+public type BadRequestError distinct ServerError;
+
 # Error for Http Status 500
-public type InternalServerError distinct BlobError;
+public type InternalServerError distinct ServerError;
+
 # Error for Http Status 416
-public type RequestedRangeNotSatisfiableError distinct BlobError;
+public type RequestedRangeNotSatisfiableError distinct ServerError;
+
 # Error for Http Status 403
-public type ForbiddenError distinct BlobError;
+public type ForbiddenError distinct ServerError;

--- a/storageservice/modules/blobs/utils.bal
+++ b/storageservice/modules/blobs/utils.bal
@@ -18,16 +18,22 @@ import azure_storage_service.utils as storage_utils;
 import ballerina/http;
 import ballerina/lang.'xml;
 import ballerina/regex;
+import ballerina/xmldata;
 
 # Handles the HTTP response.
 #
 # + response - Http response
 # + return - If successful and has xml payload, returns xml response. If successful but no payload, returns true.
 # Else returns error.
-isolated function handleResponse(http:Response response) returns xml|boolean|error {
+isolated function handleResponse(http:Response response) returns xml|boolean|Error {
     if (response.getXmlPayload() is xml) {
         if (response.statusCode == http:STATUS_OK) {
-            return check response.getXmlPayload();
+            xml<xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text>|http:ClientError xmlPayload = response.getXmlPayload();
+            if xmlPayload is http:ClientError {
+                return error ProcessingError("Error while getting xmlpayload from respose", xmlPayload);
+            } else {
+                return xmlPayload;
+            }
         } else {
             return createErrorFromXMLResponse(response);
         }
@@ -89,7 +95,7 @@ isolated function getBlobPropertyHeaders(http:Response response) returns Propert
 #
 # + response - Http response
 # + return - If successful, returns byte[]. Else returns error.
-isolated function handleGetBlobResponse(http:Response response) returns byte[]|error? {
+isolated function handleGetBlobResponse(http:Response response) returns byte[]|Error {
     if (response.statusCode == http:STATUS_OK || response.statusCode == http:STATUS_PARTIAL_CONTENT) {
         return response.getBinaryPayload();
     } else if (response.getXmlPayload() is xml) {
@@ -104,16 +110,29 @@ isolated function handleGetBlobResponse(http:Response response) returns byte[]|e
 #
 # + xmlObject - XML Object
 # + return - Returns clean XML Object
-isolated function removeDoubleQuotesFromXML(xml xmlObject) returns xml|error {
+isolated function removeDoubleQuotesFromXML(xml xmlObject) returns xml|ProcessingError {
     string cleanedStringXMLObject = regex:replaceAll(xmlObject.toString(), QUOTATION_MARK, EMPTY_STRING);
-    return 'xml:fromString(cleanedStringXMLObject);
+    do {
+        return check 'xml:fromString(cleanedStringXMLObject);
+    } on fail error e {
+        return error ProcessingError("Error while formatiing XML", e);
+    }
+}
+
+isolated function convertXMLToJson(xml input) returns json|ProcessingError {
+    json|xmldata:Error jsonResult = xmldata:toJson(input);
+    if jsonResult is xmldata:Error {
+        return error ProcessingError("Error while convertiong XML data to Json");
+    } else {
+        return jsonResult;
+    }
 }
 
 # Check HTTP response and generate errors as required.
 #
 # + response - Http response
 # + return - If unsuccessful, error
-isolated function checkAndHandleErrors(http:Response response) returns error? {
+isolated function checkAndHandleErrors(http:Response response) returns ServerError|ClientError? {
     int statusCode = response.statusCode;
     if (statusCode == http:STATUS_OK
         || statusCode == http:STATUS_CREATED
@@ -122,8 +141,8 @@ isolated function checkAndHandleErrors(http:Response response) returns error? {
     } else if (response.getXmlPayload() is xml) {
         return createErrorFromXMLResponse(response);
     } else {
-        return error BlobErrorGeneric("Undefined error occured", httpStatus=statusCode,
-             message=response.reasonPhrase);
+        return error ServerError("Unknown server error occured", httpStatus = statusCode, errorCode = "undefined",
+            message = response.reasonPhrase);
     }
 }
 
@@ -131,7 +150,7 @@ isolated function checkAndHandleErrors(http:Response response) returns error? {
 #
 # + response - Http response
 # + return - Error
-isolated function createErrorFromXMLResponse(http:Response response) returns error {
+isolated function createErrorFromXMLResponse(http:Response response) returns ServerError|ClientError {
     string errorCode = "undefined";
     string message = "unknown";
     if response.getXmlPayload() is xml {
@@ -143,29 +162,35 @@ isolated function createErrorFromXMLResponse(http:Response response) returns err
 
     match statusCode {
         http:STATUS_PRECONDITION_FAILED => {
-            return error PreconditionFailedError("Pre-conditions failed.", errorCode = errorCode, message = message);
+            return error PreconditionFailedError("Pre-conditions failed.",
+            errorCode = errorCode, message = message, httpStatus = 412);
         }
         http:STATUS_CONFLICT => {
-            return error ConflictError("Conflict occurred.", errorCode = errorCode, message = message);
+            return error ConflictError("Conflict occurred.",
+                errorCode = errorCode, message = message, httpStatus = 409);
         }
         http:STATUS_NOT_FOUND => {
-            return error NotFoundError("Resource not found.", errorCode = errorCode, message = message);
+            return error NotFoundError("Resource not found.",
+                errorCode = errorCode, message = message, httpStatus = 404);
         }
         http:STATUS_BAD_REQUEST => {
-            return error BadRequestError("Bad request received.", errorCode = errorCode, message = message);
+            return error BadRequestError("Bad request received.",
+                errorCode = errorCode, message = message, httpStatus = 400);
         }
         http:STATUS_INTERNAL_SERVER_ERROR => {
-            return error InternalServerError("Internal server error occurred.", errorCode = errorCode, message = message);
+            return error InternalServerError("Internal server error occurred.",
+                errorCode = errorCode, message = message, httpStatus = 500);
         }
         http:STATUS_RANGE_NOT_SATISFIABLE => {
-            return error RequestedRangeNotSatisfiableError("Request range is invalid.", errorCode = errorCode, message = message);
+            return error RequestedRangeNotSatisfiableError("Request range is invalid.",
+                errorCode = errorCode, message = message, httpStatus = 416);
         }
         http:STATUS_FORBIDDEN => {
-            return error ForbiddenError("Forbidden. ", errorCode = errorCode, message = message);
+            return error ForbiddenError("Forbidden. ", errorCode = errorCode, message = message, httpStatus = 403);
         }
         _ => {
-            return error BlobErrorGeneric("Undefined error occured", httpStatus = statusCode, errorCode = errorCode,
-             message = message);
+            return error ServerError("Undefined error occured", httpStatus = statusCode, errorCode = errorCode,
+            message = message);
         }
     }
 }
@@ -257,7 +282,7 @@ public isolated function generateUriParametersString(map<string> uriParameters) 
 # + resourcePath - Resource path
 # + return - Returns path
 public isolated function preparePath(string authorizationMethod, string accessKeyOrSAS, map<string> uriParameters,
-                                    string resourcePath) returns string {
+        string resourcePath) returns string {
     string path = EMPTY_STRING;
     if (authorizationMethod == SAS) {
         path = resourcePath + accessKeyOrSAS + AMPERSAND_SYMBOL;
@@ -271,8 +296,7 @@ public isolated function preparePath(string authorizationMethod, string accessKe
 # Add default headers to the request.
 #
 # + request - HTTP request
-# + return - error if unsuccessful
-public isolated function setDefaultHeaders(http:Request request) returns error? {
+public isolated function setDefaultHeaders(http:Request request) {
     request.setHeader(X_MS_VERSION, STORAGE_SERVICE_VERSION);
     request.setHeader(X_MS_DATE, storage_utils:getCurrentDate());
 }
@@ -287,11 +311,14 @@ public isolated function setDefaultHeaders(http:Request request) returns error? 
 # + uriParameters - URI parameters as map<string>
 # + return - Returns error if unsuccessful
 public isolated function addAuthorizationHeader(http:Request request, http:HttpOperation verb, string accountName,
-                                                    string accessKey, string resourceString, map<string> uriParameters)
-                                                    returns error? {
+        string accessKey, string resourceString, map<string> uriParameters)
+                                                    returns ProcessingError? {
     map<string> headerMap = populateHeaderMapFromRequest(request);
-    string sharedKeySignature = check storage_utils:generateSharedKeySignature(accountName, accessKey, verb,
+    string|error sharedKeySignature = storage_utils:generateSharedKeySignature(accountName, accessKey, verb,
         resourceString, uriParameters, headerMap);
+    if sharedKeySignature is error {
+        return error ProcessingError("Error while generating shared key signature", sharedKeySignature);
+    }
     request.setHeader(AUTHORIZATION, SHARED_KEY + WHITE_SPACE + accountName + COLON_SYMBOL + sharedKeySignature);
 }
 
@@ -311,7 +338,7 @@ public isolated function getMetaDataHeaders(http:Response response) returns map<
 }
 
 public isolated function setOptionalHeaders(http:Request request, string? clientRequestId, string? leaseId = (),
-AccessLevel? accessLevel = (), map<string>? metadata = ()) {
+        AccessLevel? accessLevel = (), map<string>? metadata = ()) {
     if accessLevel is AccessLevel {
         request.setHeader(BLOB_PUBLIC_ACCESS, accessLevel);
     }

--- a/storageservice/modules/files/records.bal
+++ b/storageservice/modules/files/records.bal
@@ -23,7 +23,7 @@ public type ConnectionConfig record {|
     *config:ConnectionConfig;
     never auth?;
     # Access key or Shared Access Signature for Azure Storage Account 
-    @display{
+    @display {
         label: "",
         kind: "password"
     }
@@ -96,7 +96,7 @@ public type StorageServicePropertiesType record {
 #
 # + Version - The version of Storage Analytics to configure
 # + Enabled - Indicates whether metrics are enabled for the File service
-# + IncludeAPIs -Indicates whether metrics should generate summary statistics for called API operations
+# + IncludeAPIs - Indicates whether metrics should generate summary statistics for called API operations
 # + RetentionPolicy - Indicates whether metrics should generate summary statistics for called API operations
 public type MetricsType record {
     string Version;
@@ -143,14 +143,14 @@ public type ProtocolSettingsType record {
     SMBType SMB?;
 };
 
-#Groups the settings for SMB.
+# Groups the settings for SMB.
 #
 # + Multichannel - Contains multi channel type record
 public type SMBType record {
     MultichannelType Multichannel?;
 };
 
-#Contains the settings for SMB multichannel.
+# Contains the settings for SMB multichannel.
 #
 # + Enabled - Toggles the state of SMB multichannel
 public type MultichannelType record {
@@ -163,14 +163,8 @@ public type AzureRecord FileServicePropertiesList|SharesList;
 # The type description of the nested records.
 public type AzureRecordType typedesc<AzureRecord>;
 
-# Represents the azure error. This will be returned if an error occurred on fileshare operations.
-public type FileShareError distinct error;
-
-# Represents the FileShare module related error.
-public type Error FileShareError;
-
 # Represnts an Azure directory.
-# 
+#
 # + Name - Name of the azure directory
 # + Properties - Properties of the directory
 public type Directory record {
@@ -265,7 +259,7 @@ public type RequestParameterList record {
 };
 
 # Represents the necessary elements for generating the authorization header.
-# 
+#
 # + azureRequest - The http request object reference to be sent to the azure
 # + azureConfig - An AzureConfiguration record
 # + httpVerb - The http method of the request
@@ -286,7 +280,7 @@ type AuthorizationDetail record {
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 # Represents optional URI parameters for ListShares operation.
-# 
+#
 # + prefix - Filters the results to return only shares whose name begins with the specified prefix
 # + marker - A string value that identifies the portion of the list to be returned with the next list operation
 # + maxresults - Specifies the maximum number of shares to return. Maximum limit and default is 5000.
@@ -301,7 +295,7 @@ public type ListShareURIParameters record {|
 |};
 
 # Represents optional URI parameters for GetDirectoryList operation.
-# 
+#
 # + prefix - Filters the results to return only directories whose name begins with the specified prefix
 # + sharesnapshot - The share snapshot to query for the list of directories
 # + marker - A string value that identifies the portion of the list to be returned with the next list operation
@@ -316,7 +310,7 @@ public type GetDirectoryListURIParameters record {|
 |};
 
 # Represents optional URI parameters for GetFileList operation.
-# 
+#
 # + prefix - Filters the results to return only files  whose name begins with the specified prefix
 # + sharesnapshot - The share snapshot to query for the list of files and directories
 # + marker - A string value that identifies the portion of the list to be returned with the next list operation
@@ -363,7 +357,7 @@ public type FileMetadataResult record {
 };
 
 # Represents optional request headers for CreateShareHeaders operation.
-# 
+#
 # + x\-ms\-share\-quota - Maximum size of the share, in GiB
 # + x\-ms\-access\-tier - Access tier of the share
 # + x\-ms\-enabled\-protocols - Enabled protocols on the share
@@ -381,7 +375,7 @@ public type URIRecord ListShareURIParameters|GetDirectoryListURIParameters|GetFi
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 # Represents a record for share not found error information.
-# 
+#
 # + storageAccountName - Name of the fileshare that error is related
 public type NoSharesFoundErrorData record {
     string storageAccountName;
@@ -390,39 +384,40 @@ public type NoSharesFoundErrorData record {
 # Defines an error for ShareNotFound
 public type NoSharesFoundError distinct error<NoSharesFoundErrorData>;
 
+# Super type error returned by connector
+public type Error ServerError|ClientError;
+
 # Defines the details of an File Service error message.
 #
-# + errorCode - Azure File Service error code
+# + httpStatus - HTTP status code associated with the error 
+# + errorCode - Azure File Service error code  
 # + message - Associated error message
-public type FileServiceErrorDetail record {|
+public type ServerErrorDetail record {|
+    int httpStatus;
     string errorCode;
     string message;
 |};
 
-# Defines the generic File Service error detail with optional error code.
-#
-# + httpStatus - HTTP status code
-# + errorCode - Associated error code
-# + message - Associated error message
-public type FileServiceErrorResponse record {|
-    int httpStatus;
-    string errorCode?;
-    string message?;
-|};
+# Error created by connector depending on server responses
+public type ServerError distinct error<ServerErrorDetail>;
 
-# Error created by connector depending on file server responses.
-public type FileSerivceError distinct error<FileServiceErrorDetail>;
+# Error created by connector when processing or invoking
+public type ClientError ProcessingError|http:ClientError;
 
-# Generic error created by connector depending on file server responses.
-public type FileServiceErrorGeneric distinct error<FileServiceErrorResponse>;
+# Error created by connector when processing, transforming data
+public type ProcessingError distinct error;
 
 # Error for Http Status 409
-public type ConflictError distinct FileSerivceError;
+public type ConflictError distinct ServerError;
+
 # Error for Http Status 404
-public type NotFoundError distinct FileSerivceError;
+public type NotFoundError distinct ServerError;
+
 # Error for Http Status 400
-public type BadRequestError distinct FileSerivceError;
+public type BadRequestError distinct ServerError;
+
 # Error for Http Status 500
-public type InternalServerError distinct FileSerivceError;
+public type InternalServerError distinct ServerError;
+
 # Error for Http Status 403
-public type ForbiddenError distinct FileSerivceError;
+public type ForbiddenError distinct ServerError;


### PR DESCRIPTION
# Description

This PR contains following updates to the error handling. 

1. Every client operation now returns `Error`
2. `Error` can be either `ServerError` or `ClientError`. Former represents errors created by responses from server (app level errors). Latter represents http client transport level errors or data transformation errors at client side. 
3. Server error detail contains HTTP status code, also it has error sub-types as defined by Microsoft in their documentation. 


