### PR TITLE
Update error handling with proper error subtypes

### DIFF
--- a/storageservice/Ballerina.toml
+++ b/storageservice/Ballerina.toml
@@ -2,7 +2,7 @@
 distribution = "2201.3.1"
 org = "ballerinax"
 name = "azure_storage_service"
-version = "4.0.1"
+version = "4.1.0"
 authors = ["Ballerina"]
 export = ["azure_storage_service", "azure_storage_service.files", "azure_storage_service.blobs"]
 keywords = ["Content & Files/File Management & Storage", "Cost/Paid", "Vendor/Microsoft"]

--- a/storageservice/Dependencies.toml
+++ b/storageservice/Dependencies.toml
@@ -352,7 +352,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "azure_storage_service"
-version = "4.0.1"
+version = "4.1.0"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "file"},

--- a/storageservice/modules/blobs/management_client.bal
+++ b/storageservice/modules/blobs/management_client.bal
@@ -15,7 +15,6 @@
 // under the License.
 
 import ballerina/http;
-import ballerina/xmldata;
 import ballerinax/'client.config;
 
 # Azure Storage Blob Management Client Object.
@@ -24,7 +23,7 @@ import ballerinax/'client.config;
 # + accessKeyOrSAS - Access Key or Shared Access Signature for the Azure Storage Account
 # + accountName - Azure Storage Account Name
 # + authorizationMethod - If authorization method is accessKey or SAS
-# 
+#
 @display {label: "Azure Storage Blob Management", iconPath: "storageservice/icon.png"}
 public isolated client class ManagementClient {
     private final http:Client httpClient;
@@ -32,14 +31,18 @@ public isolated client class ManagementClient {
     private final string accessKeyOrSAS;
     private final AuthorizationMethod authorizationMethod;
 
-    public isolated function init(ConnectionConfig config) returns error? {
-        string baseURL = string `https://${config.accountName}.blob.core.windows.net`;
-        http:ClientConfiguration httpClientConfig = check config:constructHTTPClientConfig(config);
-        httpClientConfig.http1Settings = {chunking: http:CHUNKING_NEVER};
-        self.httpClient = check new (baseURL, httpClientConfig);
-        self.accessKeyOrSAS = config.accessKeyOrSAS;
-        self.accountName = config.accountName;
-        self.authorizationMethod = config.authorizationMethod;
+    public isolated function init(ConnectionConfig config) returns Error? {
+        do {
+            string baseURL = string `https://${config.accountName}.blob.core.windows.net`;
+            http:ClientConfiguration httpClientConfig = check config:constructHTTPClientConfig(config);
+            httpClientConfig.http1Settings = {chunking: http:CHUNKING_NEVER};
+            self.httpClient = check new (baseURL, httpClientConfig);
+            self.accessKeyOrSAS = config.accessKeyOrSAS;
+            self.accountName = config.accountName;
+            self.authorizationMethod = config.authorizationMethod;
+        } on fail error e {
+            return error ProcessingError("Error while constructing HTTP Client Config", e);
+        }
     }
 
     # Get Account Information of the azure storage account.
@@ -48,30 +51,30 @@ public isolated client class ManagementClient {
     # the analytics logs when storage analytics logging is enabled. 
     # + return - If successful, returns AccountInformation. Else returns Error. 
     @display {label: "Get Account Info"}
-    remote isolated function getAccountInformation(string? clientRequestId = ()) returns @display {label: "Account information"} 
-            AccountInformationResult|error {                 
+    remote isolated function getAccountInformation(string? clientRequestId = ()) returns @display {label: "Account information"}
+            AccountInformationResult|Error {
         http:Request request = new;
-        check setDefaultHeaders(request);
+        setDefaultHeaders(request);
         map<string> uriParameterMap = {};
         uriParameterMap[RESTYPE] = ACCOUNT;
         uriParameterMap[COMP] = PROPERTIES;
         setOptionalHeaders(request, clientRequestId);
-        
-        if (self.authorizationMethod ==ACCESS_KEY) {
-            check addAuthorizationHeader(request, http:HTTP_GET, self.accountName, self.accessKeyOrSAS, EMPTY_STRING, 
+
+        if (self.authorizationMethod == ACCESS_KEY) {
+            check addAuthorizationHeader(request, http:HTTP_GET, self.accountName, self.accessKeyOrSAS, EMPTY_STRING,
                 uriParameterMap);
         }
-        
+
         string resourcePath = FORWARD_SLASH_SYMBOL;
-        string path = preparePath(self.authorizationMethod, self.accessKeyOrSAS, uriParameterMap, resourcePath);  
+        string path = preparePath(self.authorizationMethod, self.accessKeyOrSAS, uriParameterMap, resourcePath);
         map<string> headerMap = populateHeaderMapFromRequest(request);
-        http:Response response = <http:Response> check self.httpClient->get(path, headerMap);
+        http:Response response = <http:Response>check self.httpClient->get(path, headerMap);
         check checkAndHandleErrors(response);
         return convertResponseToAccountInformationType(response);
     }
 
     # Create a container in the azure storage account.
-    # 
+    #
     # + containerName - Name of the container
     # + metadata - A name-value pair to associate with the container as metadata
     # + accessLevel - Specifies whether data in the container can be accessed publicly and the level of access
@@ -79,87 +82,87 @@ public isolated client class ManagementClient {
     # the analytics logs when storage analytics logging is enabled. 
     # + return - If successful, returns Response. Else returns Error. 
     @display {label: "Create Container"}
-    remote isolated function createContainer (@display {label: "Container Name"} string containerName, 
-    AccessLevel? accessLevel = (), map<string>? metadata = (), string? clientRequestId = ()) returns 
-    @display {label: "Response"} map<json>|error {
+    remote isolated function createContainer(@display {label: "Container Name"} string containerName,
+            AccessLevel? accessLevel = (), map<string>? metadata = (), string? clientRequestId = ()) returns
+    @display {label: "Response"} map<json>|Error {
         http:Request request = new;
-        check setDefaultHeaders(request);
+        setDefaultHeaders(request);
         map<string> uriParameterMap = {};
         uriParameterMap[RESTYPE] = CONTAINER;
         setOptionalHeaders(request, clientRequestId, accessLevel = accessLevel, metadata = metadata);
 
-        if (self.authorizationMethod ==ACCESS_KEY) {
-            check addAuthorizationHeader(request, http:HTTP_PUT, self.accountName, self.accessKeyOrSAS, containerName, 
+        if (self.authorizationMethod == ACCESS_KEY) {
+            check addAuthorizationHeader(request, http:HTTP_PUT, self.accountName, self.accessKeyOrSAS, containerName,
                 uriParameterMap);
         }
 
         string resourcePath = FORWARD_SLASH_SYMBOL + containerName;
         string path = preparePath(self.authorizationMethod, self.accessKeyOrSAS, uriParameterMap, resourcePath);
-        http:Response response = <http:Response> check self.httpClient->put(path, request);
+        http:Response response = <http:Response>check self.httpClient->put(path, request);
         _ = check handleResponse(response);
         return getHeaderMapFromResponse(response);
     }
 
     # Delete a container from the azure storage account.
-    # 
+    #
     # + containerName - Name of the container
     # + clientRequestId - Provides a client-generated, opaque value with a 1 KiB character limit that is recorded in 
     # the analytics logs when storage analytics logging is enabled. 
     # + leaseId - If the container has an active lease
     # + return - If successful, returns Response. Else returns Error. 
     @display {label: "Delete Container"}
-    remote isolated function deleteContainer (@display {label: "Container Name"} string containerName,
-    string? clientRequestId = (), string? leaseId = ()) returns @display {label: "Response"} map<json>|error {
+    remote isolated function deleteContainer(@display {label: "Container Name"} string containerName,
+            string? clientRequestId = (), string? leaseId = ()) returns @display {label: "Response"} map<json>|Error {
         http:Request request = new;
-        check setDefaultHeaders(request);
+        setDefaultHeaders(request);
         map<string> uriParameterMap = {};
         uriParameterMap[RESTYPE] = CONTAINER;
         setOptionalHeaders(request, clientRequestId, leaseId);
 
-        if (self.authorizationMethod ==ACCESS_KEY) {
-            check addAuthorizationHeader(request, http:HTTP_DELETE, self.accountName, self.accessKeyOrSAS, containerName, 
+        if (self.authorizationMethod == ACCESS_KEY) {
+            check addAuthorizationHeader(request, http:HTTP_DELETE, self.accountName, self.accessKeyOrSAS, containerName,
                 uriParameterMap);
         }
 
         string resourcePath = FORWARD_SLASH_SYMBOL + containerName;
         string path = preparePath(self.authorizationMethod, self.accessKeyOrSAS, uriParameterMap, resourcePath);
-        http:Response response = <http:Response> check self.httpClient->delete(path, request);
+        http:Response response = <http:Response>check self.httpClient->delete(path, request);
         _ = check handleResponse(response);
         return getHeaderMapFromResponse(response);
     }
 
     # Get Container Properties.
-    # 
+    #
     # + containerName - Name of the container
     # + clientRequestId - Provides a client-generated, opaque value with a 1 KiB character limit that is recorded in 
     # the analytics logs when storage analytics logging is enabled. 
     # + leaseId - If the container has an active lease
     # + return - If successful, returns Container Properties. Else returns Error. 
     @display {label: "Get Container Properties"}
-    remote isolated function getContainerProperties(@display {label: "Container Name"} string containerName, 
-    string? clientRequestId = (), string? leaseId = ()) returns @display {label: "Container properties"} 
-    ContainerPropertiesResult|error {
+    remote isolated function getContainerProperties(@display {label: "Container Name"} string containerName,
+            string? clientRequestId = (), string? leaseId = ()) returns @display {label: "Container properties"}
+    ContainerPropertiesResult|Error {
         http:Request request = new;
-        check setDefaultHeaders(request);
+        setDefaultHeaders(request);
         map<string> uriParameterMap = {};
         uriParameterMap[RESTYPE] = CONTAINER;
-        setOptionalHeaders(request,clientRequestId, leaseId);
+        setOptionalHeaders(request, clientRequestId, leaseId);
 
-        if (self.authorizationMethod ==ACCESS_KEY) {
-            check addAuthorizationHeader(request, http:HTTP_HEAD, self.accountName, self.accessKeyOrSAS, containerName, 
+        if (self.authorizationMethod == ACCESS_KEY) {
+            check addAuthorizationHeader(request, http:HTTP_HEAD, self.accountName, self.accessKeyOrSAS, containerName,
                 uriParameterMap);
         }
 
         string resourcePath = FORWARD_SLASH_SYMBOL + containerName;
         string path = preparePath(self.authorizationMethod, self.accessKeyOrSAS, uriParameterMap, resourcePath);
         map<string> headerMap = populateHeaderMapFromRequest(request);
-        http:Response response = <http:Response> check self.httpClient->head(path, headerMap);
+        http:Response response = <http:Response>check self.httpClient->head(path, headerMap);
         check checkAndHandleErrors(response);
         return convertResponseToContainerPropertiesResult(response);
     }
 
     # Get Container Metadata.
-    # 
+    #
     # + containerName - Name of the container
     # + clientRequestId - Provides a client-generated, opaque value with a 1 KiB character limit that is recorded in 
     # the analytics logs when storage analytics logging is enabled. 
@@ -167,90 +170,90 @@ public isolated client class ManagementClient {
     # + return - If successful, returns Container Metadata. Else returns Error. 
     @display {label: "Container Metadata"}
     remote isolated function getContainerMetadata(@display {label: "Container Name"} string containerName,
-    string? clientRequestId = (), string? leaseId = ()) returns @display {label: "Container metadata"} 
-    ContainerMetadataResult|error {
+            string? clientRequestId = (), string? leaseId = ()) returns @display {label: "Container metadata"}
+    ContainerMetadataResult|Error {
         http:Request request = new;
-        check setDefaultHeaders(request);
+        setDefaultHeaders(request);
         map<string> uriParameterMap = {};
         uriParameterMap[RESTYPE] = CONTAINER;
         uriParameterMap[COMP] = METADATA;
         setOptionalHeaders(request, clientRequestId, leaseId);
 
-        if (self.authorizationMethod ==ACCESS_KEY) {
-            check addAuthorizationHeader(request, http:HTTP_GET, self.accountName, self.accessKeyOrSAS, containerName, 
+        if (self.authorizationMethod == ACCESS_KEY) {
+            check addAuthorizationHeader(request, http:HTTP_GET, self.accountName, self.accessKeyOrSAS, containerName,
                 uriParameterMap);
-        } 
-        
+        }
+
         string resourcePath = FORWARD_SLASH_SYMBOL + containerName;
         string path = preparePath(self.authorizationMethod, self.accessKeyOrSAS, uriParameterMap, resourcePath);
         map<string> headerMap = populateHeaderMapFromRequest(request);
-        http:Response response = <http:Response> check self.httpClient->get(path, headerMap);
+        http:Response response = <http:Response>check self.httpClient->get(path, headerMap);
         check checkAndHandleErrors(response);
         return convertResponseToContainerMetadataResult(response);
     }
 
     # Get Container ACL (gets the permissions for the specified container).
-    # 
+    #
     # + containerName - Name of the container
     # + clientRequestId - Provides a client-generated, opaque value with a 1 KiB character limit that is recorded in 
     # the analytics logs when storage analytics logging is enabled. 
     # + leaseId - If the container has an active lease
     # + return - If successful, returns container ACL. Else returns Error. 
     @display {label: "Get Containe ACL"}
-    remote isolated function getContainerACL(@display {label: "Container Name"} string containerName, string? 
-    clientRequestId = (), string? leaseId = ()) returns @display {label: "Container ACL"} ContainerACLResult|error {
-        if (self.authorizationMethod ==ACCESS_KEY ) {
+    remote isolated function getContainerACL(@display {label: "Container Name"} string containerName, string?
+    clientRequestId = (), string? leaseId = ()) returns @display {label: "Container ACL"} ContainerACLResult|Error {
+        if (self.authorizationMethod == ACCESS_KEY) {
             http:Request request = new;
-            check setDefaultHeaders(request);
+            setDefaultHeaders(request);
             map<string> uriParameterMap = {};
             uriParameterMap[RESTYPE] = CONTAINER;
             uriParameterMap[COMP] = ACL;
             setOptionalHeaders(request, clientRequestId, leaseId);
 
-            check addAuthorizationHeader(request, http:HTTP_HEAD, self.accountName, self.accessKeyOrSAS, containerName, 
+            check addAuthorizationHeader(request, http:HTTP_HEAD, self.accountName, self.accessKeyOrSAS, containerName,
                 uriParameterMap);
 
             string resourcePath = FORWARD_SLASH_SYMBOL + containerName;
             string path = preparePath(self.authorizationMethod, self.accessKeyOrSAS, uriParameterMap, resourcePath);
             map<string> headerMap = populateHeaderMapFromRequest(request);
-            http:Response response = <http:Response> check self.httpClient->head(path, headerMap);
+            http:Response response = <http:Response>check self.httpClient->head(path, headerMap);
             check checkAndHandleErrors(response);
             return convertResponseToContainerACLResult(response);
         } else {
             return error(AZURE_BLOB_ERROR_CODE, message = ("This operation is supported only with accessKey "
                 + "Authentication"));
-        } 
+        }
     }
 
     # Get Blob Service Properties.
-    # 
+    #
     # + clientRequestId - Provides a client-generated, opaque value with a 1 KiB character limit that is recorded in 
     # the analytics logs when storage analytics logging is enabled. 
     # + return - If successful, returns Blob Service Properties. Else returns Error. 
     @display {label: "Get Blob Service Properties"}
-    remote isolated function getBlobServiceProperties(string? clientRequestId = ()) returns 
-    @display {label: "Blob service properties"} BlobServicePropertiesResult|error {
+    remote isolated function getBlobServiceProperties(string? clientRequestId = ()) returns
+    @display {label: "Blob service properties"} BlobServicePropertiesResult|Error {
         http:Request request = new;
-        check setDefaultHeaders(request);
+        setDefaultHeaders(request);
         map<string> uriParameterMap = {};
         uriParameterMap[RESTYPE] = SERVICE;
         uriParameterMap[COMP] = PROPERTIES;
         setOptionalHeaders(request, clientRequestId);
 
-        if (self.authorizationMethod ==ACCESS_KEY) {
-            check addAuthorizationHeader(request, http:HTTP_GET, self.accountName, self.accessKeyOrSAS, EMPTY_STRING, 
+        if (self.authorizationMethod == ACCESS_KEY) {
+            check addAuthorizationHeader(request, http:HTTP_GET, self.accountName, self.accessKeyOrSAS, EMPTY_STRING,
                 uriParameterMap);
         }
 
         string resourcePath = FORWARD_SLASH_SYMBOL;
-        string path = preparePath(self.authorizationMethod, self.accessKeyOrSAS, uriParameterMap, resourcePath); 
+        string path = preparePath(self.authorizationMethod, self.accessKeyOrSAS, uriParameterMap, resourcePath);
         map<string> headerMap = populateHeaderMapFromRequest(request);
-        http:Response response = <http:Response> check self.httpClient->get(path, headerMap);
-        xml blobServiceProperties = <xml> check handleResponse(response);
+        http:Response response = <http:Response>check self.httpClient->get(path, headerMap);
+        xml blobServiceProperties = <xml>check handleResponse(response);
         BlobServicePropertiesResult blobServicePropertiesResult = {
-            storageServiceProperties: check xmldata:toJson(blobServiceProperties/*),
+            storageServiceProperties: check convertXMLToJson(blobServiceProperties/*),
             responseHeaders: getHeaderMapFromResponse(response)
         };
         return blobServicePropertiesResult;
-    }  
+    }
 }

--- a/storageservice/modules/blobs/types.bal
+++ b/storageservice/modules/blobs/types.bal
@@ -23,7 +23,7 @@ public type ConnectionConfig record {|
     *config:ConnectionConfig;
     never auth?;
     # Access key or Shared Access Signature for Azure Storage Account 
-    @display{
+    @display {
         label: "",
         kind: "password"
     }
@@ -44,7 +44,7 @@ public type ConnectionConfig record {|
 # + responseHeaders - reponse headers and values related to the operation
 public type AccountInformationResult record {
     string skuName;
-    string accountKind ;
+    string accountKind;
     string isHNSEnabled;
     map<json> responseHeaders;
 };
@@ -79,7 +79,7 @@ public type Blob record {
     string VersionId?;
     string IsCurrentVersion?;
     string Deleted?;
-    
+
 };
 
 # Represents Azure Storage Blob Properties.
@@ -169,11 +169,11 @@ public type Properties record {|
 # + metaData - Meta data of container
 # + responseHeaders - Response headers from Azure
 public type ContainerPropertiesResult record {
-    string eTag ; 
+    string eTag;
     string lastModified;
     string leaseStatus;
     string leaseState;
-    string leaseDuration?; 
+    string leaseDuration?;
     string publicAccess?;
     string hasImmutabilityPolicy;
     string hasLegalHold;
@@ -301,45 +301,47 @@ public enum AccessLevel {
 }
 
 # Defines the details of an error message.
-# 
+#
+# + httpStatus - HTTP status code associated with the error 
 # + errorCode - Azure Blob Storage error code  
 # + message - Associated error message
-public type BlobErrorDetail record {|
+public type ServerErrorDetail record {|
+    int httpStatus;
     string errorCode;
     string message;
 |};
 
-# Defines the generic error detail optional error code.
-#
-# + httpStatus - HTTP status code  
-# + errorCode - Associated error code
-# + message - Associated error message
-public type BlobErrorDetailGeneric record {|
-    int httpStatus;
-    string errorCode?;
-    string message?;
-|};
+# Super type error returned by connector
+public type Error ServerError|ClientError;
 
-# Error created by connector depending on server responses.
-public type BlobError distinct error<BlobErrorDetail>;
+# Error created by connector depending on server responses
+public type ServerError distinct error<ServerErrorDetail>;
 
-# Generic error created by connector depending on server responses.
-public type BlobErrorGeneric distinct error<BlobErrorDetailGeneric>;
+# Error created by connector when processing or invoking
+public type ClientError ProcessingError|http:ClientError;
 
-# Error types as per https://learn.microsoft.com/en-us/rest/api/storageservices/blob-service-error-codes 
+# Error created by connector when processing, transforming data
+public type ProcessingError distinct error;
+
+# Error types as per https://learn.microsoft.com/en-us/rest/api/storageservices/blob-service-error-codes
 
 # Error for Http Status 412
-public type PreconditionFailedError distinct BlobError; 
-# Error for Http Status 409
-public type ConflictError distinct BlobError;
-# Error for Http Status 404
-public type NotFoundError distinct BlobError;
-# Error for Http Status 400
-public type BadRequestError distinct BlobError;
-# Error for Http Status 500
-public type InternalServerError distinct BlobError;
-# Error for Http Status 416
-public type RequestedRangeNotSatisfiableError distinct BlobError;
-# Error for Http Status 403
-public type ForbiddenError distinct BlobError;
+public type PreconditionFailedError distinct ServerError;
 
+# Error for Http Status 409
+public type ConflictError distinct ServerError;
+
+# Error for Http Status 404
+public type NotFoundError distinct ServerError;
+
+# Error for Http Status 400
+public type BadRequestError distinct ServerError;
+
+# Error for Http Status 500
+public type InternalServerError distinct ServerError;
+
+# Error for Http Status 416
+public type RequestedRangeNotSatisfiableError distinct ServerError;
+
+# Error for Http Status 403
+public type ForbiddenError distinct ServerError;

--- a/storageservice/modules/files/records.bal
+++ b/storageservice/modules/files/records.bal
@@ -23,7 +23,7 @@ public type ConnectionConfig record {|
     *config:ConnectionConfig;
     never auth?;
     # Access key or Shared Access Signature for Azure Storage Account 
-    @display{
+    @display {
         label: "",
         kind: "password"
     }
@@ -96,7 +96,7 @@ public type StorageServicePropertiesType record {
 #
 # + Version - The version of Storage Analytics to configure
 # + Enabled - Indicates whether metrics are enabled for the File service
-# + IncludeAPIs -Indicates whether metrics should generate summary statistics for called API operations
+# + IncludeAPIs - Indicates whether metrics should generate summary statistics for called API operations
 # + RetentionPolicy - Indicates whether metrics should generate summary statistics for called API operations
 public type MetricsType record {
     string Version;
@@ -143,14 +143,14 @@ public type ProtocolSettingsType record {
     SMBType SMB?;
 };
 
-#Groups the settings for SMB.
+# Groups the settings for SMB.
 #
 # + Multichannel - Contains multi channel type record
 public type SMBType record {
     MultichannelType Multichannel?;
 };
 
-#Contains the settings for SMB multichannel.
+# Contains the settings for SMB multichannel.
 #
 # + Enabled - Toggles the state of SMB multichannel
 public type MultichannelType record {
@@ -163,14 +163,8 @@ public type AzureRecord FileServicePropertiesList|SharesList;
 # The type description of the nested records.
 public type AzureRecordType typedesc<AzureRecord>;
 
-# Represents the azure error. This will be returned if an error occurred on fileshare operations.
-public type FileShareError distinct error;
-
-# Represents the FileShare module related error.
-public type Error FileShareError;
-
 # Represnts an Azure directory.
-# 
+#
 # + Name - Name of the azure directory
 # + Properties - Properties of the directory
 public type Directory record {
@@ -265,7 +259,7 @@ public type RequestParameterList record {
 };
 
 # Represents the necessary elements for generating the authorization header.
-# 
+#
 # + azureRequest - The http request object reference to be sent to the azure
 # + azureConfig - An AzureConfiguration record
 # + httpVerb - The http method of the request
@@ -286,7 +280,7 @@ type AuthorizationDetail record {
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 # Represents optional URI parameters for ListShares operation.
-# 
+#
 # + prefix - Filters the results to return only shares whose name begins with the specified prefix
 # + marker - A string value that identifies the portion of the list to be returned with the next list operation
 # + maxresults - Specifies the maximum number of shares to return. Maximum limit and default is 5000.
@@ -301,7 +295,7 @@ public type ListShareURIParameters record {|
 |};
 
 # Represents optional URI parameters for GetDirectoryList operation.
-# 
+#
 # + prefix - Filters the results to return only directories whose name begins with the specified prefix
 # + sharesnapshot - The share snapshot to query for the list of directories
 # + marker - A string value that identifies the portion of the list to be returned with the next list operation
@@ -316,7 +310,7 @@ public type GetDirectoryListURIParameters record {|
 |};
 
 # Represents optional URI parameters for GetFileList operation.
-# 
+#
 # + prefix - Filters the results to return only files  whose name begins with the specified prefix
 # + sharesnapshot - The share snapshot to query for the list of files and directories
 # + marker - A string value that identifies the portion of the list to be returned with the next list operation
@@ -363,7 +357,7 @@ public type FileMetadataResult record {
 };
 
 # Represents optional request headers for CreateShareHeaders operation.
-# 
+#
 # + x\-ms\-share\-quota - Maximum size of the share, in GiB
 # + x\-ms\-access\-tier - Access tier of the share
 # + x\-ms\-enabled\-protocols - Enabled protocols on the share
@@ -381,7 +375,7 @@ public type URIRecord ListShareURIParameters|GetDirectoryListURIParameters|GetFi
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 # Represents a record for share not found error information.
-# 
+#
 # + storageAccountName - Name of the fileshare that error is related
 public type NoSharesFoundErrorData record {
     string storageAccountName;
@@ -390,39 +384,40 @@ public type NoSharesFoundErrorData record {
 # Defines an error for ShareNotFound
 public type NoSharesFoundError distinct error<NoSharesFoundErrorData>;
 
+# Super type error returned by connector
+public type Error ServerError|ClientError;
+
 # Defines the details of an File Service error message.
-# 
+#
+# + httpStatus - HTTP status code associated with the error 
 # + errorCode - Azure File Service error code  
 # + message - Associated error message
-public type FileServiceErrorDetail record {|
+public type ServerErrorDetail record {|
+    int httpStatus;
     string errorCode;
     string message;
 |};
 
-# Defines the generic File Service error detail with optional error code.
-#
-# + httpStatus - HTTP status code  
-# + errorCode - Associated error code 
-# + message - Associated error message
-public type FileServiceErrorResponse record {|
-    int httpStatus;
-    string errorCode?;
-    string message?;
-|};
+# Error created by connector depending on server responses
+public type ServerError distinct error<ServerErrorDetail>;
 
-# Error created by connector depending on file server responses.
-public type FileSerivceError distinct error<FileServiceErrorDetail>;
+# Error created by connector when processing or invoking
+public type ClientError ProcessingError|http:ClientError;
 
-# Generic error created by connector depending on file server responses.
-public type FileServiceErrorGeneric distinct error<FileServiceErrorResponse>;
+# Error created by connector when processing, transforming data
+public type ProcessingError distinct error;
 
 # Error for Http Status 409
-public type ConflictError distinct FileSerivceError;
+public type ConflictError distinct ServerError;
+
 # Error for Http Status 404
-public type NotFoundError distinct FileSerivceError;
+public type NotFoundError distinct ServerError;
+
 # Error for Http Status 400
-public type BadRequestError distinct FileSerivceError;
+public type BadRequestError distinct ServerError;
+
 # Error for Http Status 500
-public type InternalServerError distinct FileSerivceError;
+public type InternalServerError distinct ServerError;
+
 # Error for Http Status 403
-public type ForbiddenError distinct FileSerivceError;
+public type ForbiddenError distinct ServerError;

--- a/storageservice/modules/files/utils.bal
+++ b/storageservice/modules/files/utils.bal
@@ -26,51 +26,56 @@ import ballerina/xmldata;
 #
 # + xmlPayload - XML payload
 # + return - If success, returns formatted xml else error
-isolated function removeDoubleQuotesFromXML(xml xmlPayload) returns xml|error {
-    return 'xml:fromString(regex:replaceAll(xmlPayload.toString(), QUOTATION_MARK, EMPTY_STRING));
+isolated function removeDoubleQuotesFromXML(xml xmlPayload) returns xml|ProcessingError {
+    string cleanedStringXMLObject = regex:replaceAll(xmlPayload.toString(), QUOTATION_MARK, EMPTY_STRING);
+    do {
+        return check 'xml:fromString(cleanedStringXMLObject);
+    } on fail error e {
+        return error ProcessingError("Error while formatiing XML", e);
+    }
 }
 
-# Coverts records to xml.
+# Converts records to xml.
 #
 # + recordContent - Contents to be converted
 # + return - If success, returns xml. Else the error.
-isolated function convertRecordToXml(anydata recordContent) returns xml|error {
+isolated function convertRecordToXml(anydata recordContent) returns xml|ProcessingError {
     json|error convertedContent = recordContent.cloneWithType(json);
     if (convertedContent is json) {
         var xmlData = xmldata:fromJson(convertedContent);
         if (xmlData is xml) {
             return xmlData;
         } else {
-            fail error(XML_TO_JSON_CONVERSION_ERROR);
+            return error ProcessingError("Error while converting record to json", xmlData);
         }
     } else {
-        return convertedContent;
+        return error ProcessingError("Error while converting record to json", convertedContent);
     }
 }
 
 # Check HTTP response and generate errors as required.
 #
 # + response - Http response to inspect
-# + return - If checks are failed returns error 
-isolated function checkAndHandleErrors(http:Response response) returns error? {
+# + return - If checks are failed returns error
+isolated function checkAndHandleErrors(http:Response response) returns ServerError|ClientError? {
     int statusCode = response.statusCode;
-    if (statusCode == http:STATUS_OK 
-        || statusCode == http:STATUS_CREATED 
-        || statusCode == http:STATUS_ACCEPTED 
+    if (statusCode == http:STATUS_OK
+        || statusCode == http:STATUS_CREATED
+        || statusCode == http:STATUS_ACCEPTED
         || statusCode == http:STATUS_NO_CONTENT) {
     } else if (response.getXmlPayload() is xml) {
         return createErrorFromXMLResponse(response);
     } else {
-        return error FileServiceErrorGeneric("Undefined error occured", httpStatus=statusCode,
-             message=response.reasonPhrase);
+        return error ServerError("Undefined error occured", httpStatus = statusCode,
+            errorCode = "Undefined", message = "Unknown");
     }
 }
 
 # Create error from xml response.
 #
 # + response - Http response to construct error from
-# + return - FileServerError or FileServiceErrorGeneric type of error 
-isolated function createErrorFromXMLResponse(http:Response response) returns error {
+# + return - FileServerError or FileServiceErrorGeneric type of error
+isolated function createErrorFromXMLResponse(http:Response response) returns ServerError|ClientError {
     string errorCode = "undefined";
     string message = "unknown";
     if response.getXmlPayload() is xml {
@@ -82,23 +87,23 @@ isolated function createErrorFromXMLResponse(http:Response response) returns err
 
     match statusCode {
         http:STATUS_CONFLICT => {
-            return error ConflictError("Conflict occurred.", errorCode = errorCode, message = message);
+            return error ConflictError("Conflict occurred.", httpStatus = 409, errorCode = errorCode, message = message);
         }
         http:STATUS_NOT_FOUND => {
-            return error NotFoundError("Resource not found.", errorCode = errorCode, message = message);
+            return error NotFoundError("Resource not found.", httpStatus = 404, errorCode = errorCode, message = message);
         }
         http:STATUS_BAD_REQUEST => {
-            return error BadRequestError("Bad request received.", errorCode = errorCode, message = message);
+            return error BadRequestError("Bad request received.", httpStatus = 400, errorCode = errorCode, message = message);
         }
         http:STATUS_INTERNAL_SERVER_ERROR => {
-            return error InternalServerError("Internal server error occurred.", errorCode = errorCode, message = message);
+            return error InternalServerError("Internal server error occurred.", httpStatus = 500, errorCode = errorCode, message = message);
         }
         http:STATUS_FORBIDDEN => {
-            return error ForbiddenError("Forbidden. ", errorCode = errorCode, message = message);
+            return error ForbiddenError("Forbidden. ", httpStatus = 403, errorCode = errorCode, message = message);
         }
         _ => {
-            return error FileServiceErrorGeneric("Undefined error occured", httpStatus = statusCode, errorCode = errorCode,
-             message = message);
+            return error ServerError("Undefined error occured", httpStatus = statusCode, errorCode = errorCode,
+            message = message);
         }
     }
 }
@@ -108,7 +113,7 @@ isolated function createErrorFromXMLResponse(http:Response response) returns err
 # + filePath - Path to the destination directory
 # + payload - The content to be written
 # + return - if success returns true else the error
-isolated function writeFile(string filePath, byte[] payload) returns error? {
+isolated function writeFile(string filePath, byte[] payload) returns io:Error? {
     io:WritableByteChannel writeableFile = check io:openWritableFile(filePath);
     int index = 0;
     while (index < payload.length()) {
@@ -129,7 +134,7 @@ isolated function setAzureRequestHeaders(http:Request request, RequestHeaders re
 }
 
 # Sets required request headers.
-# 
+#
 # + request - Request object reference
 # + specificRequiredHeaders - Request headers as a key value map
 isolated function setSpecificRequestHeaders(http:Request request, map<string> specificRequiredHeaders) {
@@ -140,33 +145,36 @@ isolated function setSpecificRequestHeaders(http:Request request, map<string> sp
 }
 
 # Prepares the authorized header for the Shared key authorization.
-# 
+#
 # + authDetail - The records that includes the necessary detail for the authorization header creation
 # + return - Returns error if unsuccessful
-isolated function prepareAuthorizationHeaders(AuthorizationDetail authDetail) returns error? {
+isolated function prepareAuthorizationHeaders(AuthorizationDetail authDetail) returns ProcessingError? {
     map<string> headerMap = populateHeaderMapFromRequest(authDetail.azureRequest);
     URIRecord? uriRecord = authDetail?.uriParameterRecord;
     map<string> uriMap = {};
     if (uriRecord is ()) {
-       uriMap = convertRecordtoStringMap(requiredURIParameters = authDetail.requiredURIParameters);
+        uriMap = convertRecordtoStringMap(requiredURIParameters = authDetail.requiredURIParameters);
     } else {
-       uriMap = convertRecordtoStringMap(<URIRecord>uriRecord, authDetail.requiredURIParameters);
+        uriMap = convertRecordtoStringMap(<URIRecord>uriRecord, authDetail.requiredURIParameters);
     }
     string azureResourcePath = authDetail?.resourcePath is () ? (EMPTY_STRING) : authDetail?.resourcePath.toString();
-    string sharedKeySignature = check storage_utils:generateSharedKeySignature(authDetail.azureConfig
+    string|error sharedKeySignature = storage_utils:generateSharedKeySignature(authDetail.azureConfig
         .accountName, authDetail.azureConfig.accessKeyOrSAS, authDetail.httpVerb, azureResourcePath, uriMap,
         headerMap);
-    authDetail.azureRequest.setHeader(AUTHORIZATION, SHARED_KEY + WHITE_SPACE + authDetail.azureConfig.accountName 
+    if sharedKeySignature is error {
+        return error ProcessingError("Error while generating shared key signature", sharedKeySignature);
+    }
+    authDetail.azureRequest.setHeader(AUTHORIZATION, SHARED_KEY + WHITE_SPACE + authDetail.azureConfig.accountName
         + COLON_SYMBOL + sharedKeySignature);
 }
 
 # Converts a record to string type map.
-# 
+#
 # + uriParameters - The record of type URIRecord
 # + requiredURIParameters - The string type map of required URI Parameters
 # + return - If success, returns map<string>. Else empty map.
-isolated function convertRecordtoStringMap(URIRecord? uriParameters = (), map<string> requiredURIParameters = {}) 
-                                           returns map<string> {
+isolated function convertRecordtoStringMap(URIRecord? uriParameters = (), map<string> requiredURIParameters = {})
+                                            returns map<string> {
     map<string> stringMap = {};
     if (typeof uriParameters is typedesc<ListShareURIParameters>) {
         stringMap[PREFIX] = uriParameters?.prefix.toString();
@@ -174,18 +182,18 @@ isolated function convertRecordtoStringMap(URIRecord? uriParameters = (), map<st
         stringMap[MAX_RESULTS] = uriParameters?.maxresults.toString();
         stringMap[INCLUDE] = uriParameters?.include.toString();
         stringMap[TIMEOUT] = uriParameters?.timeout.toString();
-    } else if (typeof uriParameters is typedesc<GetDirectoryListURIParameters> || typeof uriParameters is 
+    } else if (typeof uriParameters is typedesc<GetDirectoryListURIParameters> || typeof uriParameters is
         typedesc<GetFileListURIParameters>) {
         stringMap[PREFIX] = uriParameters?.prefix.toString();
         stringMap[MARKER] = uriParameters?.marker.toString();
         stringMap[MAX_RESULTS] = uriParameters?.maxresults.toString();
         stringMap[SHARES_SNAPSHOT] = uriParameters?.sharesnapshot.toString();
         stringMap[TIMEOUT] = uriParameters?.timeout.toString();
-    } 
+    }
     if (requiredURIParameters.length() != 0) {
         string[] keys = requiredURIParameters.keys();
-        foreach string keyItem in keys  {
-           stringMap[keyItem] = requiredURIParameters.get(keyItem); 
+        foreach string keyItem in keys {
+            stringMap[keyItem] = requiredURIParameters.get(keyItem);
         }
     }
     map<string> filteredMap = {};
@@ -200,7 +208,7 @@ isolated function convertRecordtoStringMap(URIRecord? uriParameters = (), map<st
 }
 
 # Gets the headers from a request as a map.
-# 
+#
 # + request - http:Request type object reference
 # + return - If success, returns map<string>. Else empty map.
 isolated function populateHeaderMapFromRequest(http:Request request) returns map<string> {
@@ -229,43 +237,43 @@ isolated function getHeaderFromRequest(http:Request request, string headerName) 
 }
 
 # Sets the opitional URI parameters.
-# 
+#
 # + uriRecord - URL parameters as records
 # + return - if success returns the appended URI paramteres as a string else an error
 isolated function setOptionalURIParametersFromRecord(URIRecord uriRecord) returns string? {
     string optionalURIs = EMPTY_STRING;
     if (typeof uriRecord is typedesc<ListShareURIParameters>) {
-        optionalURIs = uriRecord?.prefix is () ? optionalURIs : (optionalURIs + AMPERSAND + PREFIX + EQUALS_SIGN 
+        optionalURIs = uriRecord?.prefix is () ? optionalURIs : (optionalURIs + AMPERSAND + PREFIX + EQUALS_SIGN
             + uriRecord?.prefix.toString());
-        optionalURIs = uriRecord?.marker is () ? optionalURIs : (optionalURIs + AMPERSAND + MARKER + EQUALS_SIGN 
+        optionalURIs = uriRecord?.marker is () ? optionalURIs : (optionalURIs + AMPERSAND + MARKER + EQUALS_SIGN
             + uriRecord?.marker.toString());
-        optionalURIs = uriRecord?.maxresults is () ? optionalURIs : (optionalURIs + AMPERSAND + MAX_RESULTS 
+        optionalURIs = uriRecord?.maxresults is () ? optionalURIs : (optionalURIs + AMPERSAND + MAX_RESULTS
             + EQUALS_SIGN + uriRecord?.maxresults.toString());
-        optionalURIs = uriRecord?.include is () ? optionalURIs : (optionalURIs + AMPERSAND + INCLUDE + EQUALS_SIGN 
+        optionalURIs = uriRecord?.include is () ? optionalURIs : (optionalURIs + AMPERSAND + INCLUDE + EQUALS_SIGN
             + uriRecord?.include.toString());
-        optionalURIs = uriRecord?.timeout is () ? optionalURIs : (optionalURIs + AMPERSAND + TIMEOUT + EQUALS_SIGN 
+        optionalURIs = uriRecord?.timeout is () ? optionalURIs : (optionalURIs + AMPERSAND + TIMEOUT + EQUALS_SIGN
             + uriRecord?.timeout.toString());
-        return optionalURIs;      
-    } else if (typeof uriRecord is typedesc<GetDirectoryListURIParameters> || typeof uriRecord is 
+        return optionalURIs;
+    } else if (typeof uriRecord is typedesc<GetDirectoryListURIParameters> || typeof uriRecord is
         typedesc<GetFileListURIParameters>) {
         optionalURIs = uriRecord?.prefix is () ? optionalURIs : (optionalURIs + AMPERSAND + PREFIX + EQUALS_SIGN
             + uriRecord?.prefix.toString());
-        optionalURIs = uriRecord?.sharesnapshot is () ? optionalURIs : (optionalURIs + AMPERSAND + SHARES_SNAPSHOT 
+        optionalURIs = uriRecord?.sharesnapshot is () ? optionalURIs : (optionalURIs + AMPERSAND + SHARES_SNAPSHOT
             + EQUALS_SIGN + uriRecord?.sharesnapshot.toString());
-        optionalURIs = uriRecord?.marker is () ? optionalURIs : (optionalURIs + AMPERSAND + MARKER + EQUALS_SIGN 
+        optionalURIs = uriRecord?.marker is () ? optionalURIs : (optionalURIs + AMPERSAND + MARKER + EQUALS_SIGN
             + uriRecord?.marker.toString());
-        optionalURIs = uriRecord?.maxresults is () ? optionalURIs : (optionalURIs + AMPERSAND + MAX_RESULTS 
+        optionalURIs = uriRecord?.maxresults is () ? optionalURIs : (optionalURIs + AMPERSAND + MAX_RESULTS
             + EQUALS_SIGN + uriRecord?.maxresults.toString());
-        optionalURIs = uriRecord?.timeout is () ? optionalURIs : (optionalURIs + AMPERSAND + TIMEOUT + EQUALS_SIGN 
+        optionalURIs = uriRecord?.timeout is () ? optionalURIs : (optionalURIs + AMPERSAND + TIMEOUT + EQUALS_SIGN
             + uriRecord?.timeout.toString());
         return optionalURIs;
-    } else  {
+    } else {
         return;
     }
 }
 
 # Send request to create a file in the azure file share with the given size in byte.
-# 
+#
 # + httpClient - Http client type reference 
 # + fileShareName - Name of the fileShare
 # + fileName - Name of the File in Azure to be created
@@ -273,44 +281,43 @@ isolated function setOptionalURIParametersFromRecord(URIRecord uriRecord) return
 # + azureConfig - Azure Configuration
 # + azureDirectoryPath - Directory path in Azure to the file
 # + return - if success returns true as a string else the error
-isolated function createFileInternal(http:Client httpClient, string fileShareName, string fileName, int fileSizeInByte, 
-                            ConnectionConfig azureConfig, string? azureDirectoryPath = ()) 
-                            returns error? {
+isolated function createFileInternal(http:Client httpClient, string fileShareName, string fileName, int fileSizeInByte,
+        ConnectionConfig azureConfig, string? azureDirectoryPath = ()) returns Error? {
     string requestPath = SLASH + fileShareName;
     requestPath = azureDirectoryPath is () ? requestPath : (requestPath + SLASH + azureDirectoryPath);
     requestPath = requestPath + SLASH + fileName;
     http:Request request = new;
     map<string> requiredSpecificHeaders = {
-        [X_MS_FILE_PERMISSION]: INHERIT,
-        [x_MS_FILE_ATTRIBUTES]: NONE,
-        [X_MS_FILE_CREATION_TIME]: NOW,
-        [X_MS_FILE_LAST_WRITE_TIME]: NOW,
-        [CONTENT_LENGTH]: ZERO,
-        [X_MS_CONTENT_LENGTH]: fileSizeInByte.toString(),
-        [X_MS_TYPE]: FILE_TYPE
+        [X_MS_FILE_PERMISSION] : INHERIT,
+        [x_MS_FILE_ATTRIBUTES] : NONE,
+        [X_MS_FILE_CREATION_TIME] : NOW,
+        [X_MS_FILE_LAST_WRITE_TIME] : NOW,
+        [CONTENT_LENGTH] : ZERO,
+        [X_MS_CONTENT_LENGTH] : fileSizeInByte.toString(),
+        [X_MS_TYPE] : FILE_TYPE
     };
     setSpecificRequestHeaders(request, requiredSpecificHeaders);
     if (azureConfig.authorizationMethod == ACCESS_KEY) {
-        map<string> requiredURIParameters ={}; 
-        string resourcePathForSharedkeyAuth = azureDirectoryPath is () ? (fileShareName + SLASH + fileName) 
+        map<string> requiredURIParameters = {};
+        string resourcePathForSharedkeyAuth = azureDirectoryPath is () ? (fileShareName + SLASH + fileName)
             : (fileShareName + SLASH + azureDirectoryPath + SLASH + fileName);
-            AuthorizationDetail  authorizationDetail = {
-                azureRequest: request,
-                azureConfig: azureConfig,
-                httpVerb: http:HTTP_PUT,
-                resourcePath: resourcePathForSharedkeyAuth,
-                requiredURIParameters: requiredURIParameters
-            };
-            check prepareAuthorizationHeaders(authorizationDetail);     
-        } else {
-            requestPath = requestPath.concat(azureConfig.accessKeyOrSAS);
-        }
-    http:Response response = <http:Response> check httpClient->put(requestPath, request);
+        AuthorizationDetail authorizationDetail = {
+            azureRequest: request,
+            azureConfig: azureConfig,
+            httpVerb: http:HTTP_PUT,
+            resourcePath: resourcePathForSharedkeyAuth,
+            requiredURIParameters: requiredURIParameters
+        };
+        check prepareAuthorizationHeaders(authorizationDetail);
+    } else {
+        requestPath = requestPath.concat(azureConfig.accessKeyOrSAS);
+    }
+    http:Response response = <http:Response>check httpClient->put(requestPath, request);
     check checkAndHandleErrors(response);
 }
 
 # Send request to create a file in the azure file share with the given size in byte.
-# 
+#
 # + httpClient - Http client type reference 
 # + fileShareName - Name of the fileShare
 # + localFilePath - Path of the file in local that is uploaded to azure
@@ -319,20 +326,23 @@ isolated function createFileInternal(http:Client httpClient, string fileShareNam
 # + azureConfig - Azure Configuration
 # + azureDirectoryPath - Directory path in Azure to the file
 # + return - if success returns true else the error
-isolated function putRangeInternal(http:Client httpClient, string fileShareName, string localFilePath, 
-                                   string azureFileName, ConnectionConfig azureConfig, 
-                                   int fileSizeInByte, string? azureDirectoryPath = ()) returns error? {
+isolated function putRangeInternal(http:Client httpClient, string fileShareName, string localFilePath,
+        string azureFileName, ConnectionConfig azureConfig,
+        int fileSizeInByte, string? azureDirectoryPath = ()) returns ClientError? {
     string requestPath = SLASH + fileShareName;
     requestPath = azureDirectoryPath is () ? requestPath : (requestPath + SLASH + azureDirectoryPath);
     requestPath = requestPath + SLASH + azureFileName + QUESTION_MARK + PUT_RANGE_PATH;
-    stream<byte[] & readonly, io:Error?> fileStream = check io:fileReadBlocksAsStream(localFilePath, MAX_UPLOADING_BYTE_SIZE);
-    check iterateFileStream(httpClient,fileStream,fileSizeInByte,requestPath,fileShareName,azureFileName,azureConfig, 
+    stream<io:Block, io:Error?>|io:Error fileStream = io:fileReadBlocksAsStream(localFilePath, MAX_UPLOADING_BYTE_SIZE);
+    if fileStream is io:Error {
+        return error ProcessingError("Error while reading file as stream path = " + localFilePath, fileStream);
+    }
+    check iterateFileStream(httpClient, fileStream, fileSizeInByte, requestPath, fileShareName, azureFileName, azureConfig,
         azureDirectoryPath);
 }
 
-isolated function putRangeAsByteArray(http:Client httpClient, string fileShareName, byte[] fileContent, 
-                                   string azureFileName, ConnectionConfig azureConfig, 
-                                   int fileSizeInByte, string? azureDirectoryPath = ()) returns error? {
+isolated function putRangeAsByteArray(http:Client httpClient, string fileShareName, byte[] fileContent,
+        string azureFileName, ConnectionConfig azureConfig,
+        int fileSizeInByte, string? azureDirectoryPath = ()) returns ClientError|ServerError? {
     string requestPath = SLASH + fileShareName;
     requestPath = azureDirectoryPath is () ? requestPath : (requestPath + SLASH + azureDirectoryPath);
     requestPath = requestPath + SLASH + azureFileName + QUESTION_MARK + PUT_RANGE_PATH;
@@ -340,45 +350,46 @@ isolated function putRangeAsByteArray(http:Client httpClient, string fileShareNa
     int index = 0;
     addPutRangeMandatoryHeaders(index, request, fileContent.length(), fileContent);
     if (azureConfig.authorizationMethod == ACCESS_KEY) {
-        check addPutRangeHeadersForSharedKey(request, fileShareName, azureFileName, azureConfig, azureDirectoryPath);      
+        check addPutRangeHeadersForSharedKey(request, fileShareName, azureFileName, azureConfig, azureDirectoryPath);
     } else {
-            string tokenWithAmpersand = AMPERSAND.concat(azureConfig.accessKeyOrSAS.substring(1));
-            requestPath = requestPath.concat(tokenWithAmpersand);
+        string tokenWithAmpersand = AMPERSAND.concat(azureConfig.accessKeyOrSAS.substring(1));
+        requestPath = requestPath.concat(tokenWithAmpersand);
     }
-    http:Response response = <http:Response> check httpClient->put(requestPath, request);
-    if (response.statusCode != http:STATUS_CREATED) {
-        fail error(FILE_UPLOAD_AS_BYTE_ARRAY_FAILED); 
-    }
+    http:Response response = <http:Response>check httpClient->put(requestPath, request);
+    check checkAndHandleErrors(response);
 }
 
-isolated function iterateFileStream(http:Client httpClient,stream<byte[] & readonly, io:Error?>  fileStream, 
-                                  int fileSizeInByte, string requestPathParent, string fileShareName, 
-                                  string azureFileName, ConnectionConfig azureConfig, 
-                                  string? azureDirectoryPath = ()) returns error? {
+isolated function iterateFileStream(http:Client httpClient, stream<byte[] & readonly, io:Error?> fileStream,
+        int fileSizeInByte, string requestPathParent, string fileShareName,
+        string azureFileName, ConnectionConfig azureConfig,
+        string? azureDirectoryPath = ()) returns ClientError? {
     int index = 0;
     boolean isFirstRequest = true;
     int remainingBytesAmount = fileSizeInByte;
     boolean isOver = false;
     string requestPath = requestPathParent;
     while !isOver {
-        record {| byte[] & readonly value; |}? byteBlock  = check fileStream.next();
-        if(byteBlock is ()) {
+        record {|byte[] & readonly value;|}|io:Error? byteBlock = fileStream.next();
+        if (byteBlock is io:Error) {
+            return error ProcessingError("Error while reading file stream", byteBlock);
+        }
+        if (byteBlock is ()) {
             isOver = true;
         } else {
             if (remainingBytesAmount > MAX_UPLOADING_BYTE_SIZE) {
                 http:Request request = new;
                 addPutRangeMandatoryHeaders(index, request, (index + MAX_UPLOADING_BYTE_SIZE), byteBlock.value);
                 if (azureConfig.authorizationMethod == ACCESS_KEY) {
-                    check addPutRangeHeadersForSharedKey(request, fileShareName, azureFileName, azureConfig, 
-                                                         azureDirectoryPath);      
+                    check addPutRangeHeadersForSharedKey(request, fileShareName, azureFileName, azureConfig,
+                                                        azureDirectoryPath);
                 } else {
                     if (isFirstRequest) {
                         string tokenWithAmpersand = AMPERSAND.concat(azureConfig.accessKeyOrSAS.substring(1));
                         requestPath = requestPath.concat(tokenWithAmpersand);
                         isFirstRequest = false;
-                    } 
+                    }
                 }
-                http:Response response = <http:Response> check httpClient->put(requestPath, request);
+                http:Response response = <http:Response>check httpClient->put(requestPath, request);
                 if (response.statusCode == http:STATUS_CREATED) {
                     index = index + MAX_UPLOADING_BYTE_SIZE;
                     remainingBytesAmount = remainingBytesAmount - MAX_UPLOADING_BYTE_SIZE;
@@ -388,37 +399,37 @@ isolated function iterateFileStream(http:Client httpClient,stream<byte[] & reado
                 http:Request lastRequest = new;
                 addPutRangeMandatoryHeaders(index, lastRequest, fileSizeInByte, lastUploadRequest);
                 if (azureConfig.authorizationMethod == ACCESS_KEY) {
-                    check addPutRangeHeadersForSharedKey(lastRequest, fileShareName, azureFileName, azureConfig, 
-                        azureDirectoryPath);  
+                    check addPutRangeHeadersForSharedKey(lastRequest, fileShareName, azureFileName, azureConfig,
+                        azureDirectoryPath);
                 } else {
                     if (isFirstRequest) {
                         string tokenWithAmpersand = AMPERSAND.concat(azureConfig.accessKeyOrSAS.substring(1));
                         requestPath = requestPath.concat(tokenWithAmpersand);
                         isFirstRequest = false;
-                    } 
+                    }
                 }
-                http:Response responseLast = <http:Response> check httpClient->put(requestPath, lastRequest);
+                http:Response responseLast = <http:Response>check httpClient->put(requestPath, lastRequest);
                 if (responseLast.statusCode != http:STATUS_CREATED) {
                     xml errorMessage = check responseLast.getXmlPayload();
                     log:printError(errorMessage.toString(), statusCode = responseLast.statusCode);
                 }
-            } 
+            }
         }
-            
+
     }
 }
 
 # Set mandatory headers for putRange request.
-# 
+#
 # + startIndex - Starting index of the byte content
 # + request - HTTP request 
 # + lastIndex - Last inded of the byte content
 # + byteContent - Byte array of content
 isolated function addPutRangeMandatoryHeaders(int startIndex, http:Request request, int lastIndex, byte[] byteContent) {
     map<string> requiredSpecificHeaders = {
-        [X_MS_RANGE]: string `bytes=${startIndex.toString()}-${(lastIndex - 1).toString()}`,
-        [CONTENT_LENGTH]: byteContent.length().toString(),
-        [X_MS_WRITE]: UPDATE 
+        [X_MS_RANGE] : string `bytes=${startIndex.toString()}-${(lastIndex - 1).toString()}`,
+        [CONTENT_LENGTH] : byteContent.length().toString(),
+        [X_MS_WRITE] : UPDATE
     };
     log:printDebug("Uplodaing Byte-Range: " + requiredSpecificHeaders.get(X_MS_RANGE).toString());
     setSpecificRequestHeaders(request, requiredSpecificHeaders);
@@ -426,22 +437,22 @@ isolated function addPutRangeMandatoryHeaders(int startIndex, http:Request reque
 }
 
 # Set sharedKey related headers for putRange request.
-# 
+#
 # + request - HTTP request
 # + fileShareName - Fileshare name
 # + azureFileName - File name in azure
 # + azureConfig - Azure configuration
 # + azureDirectoryPath - Directory path in azure
 # + return - If success, returns null.  Else returns error
-isolated function addPutRangeHeadersForSharedKey(http:Request request, string fileShareName, string azureFileName, 
-                                                 ConnectionConfig azureConfig, string? azureDirectoryPath = 
-                                                 ()) returns error? {
-    map<string> requiredURIParameters = {}; 
+isolated function addPutRangeHeadersForSharedKey(http:Request request, string fileShareName, string azureFileName,
+        ConnectionConfig azureConfig, string? azureDirectoryPath =
+                                                ()) returns ProcessingError? {
+    map<string> requiredURIParameters = {};
     requiredURIParameters[COMP] = RANGE;
     request.setHeader(CONTENT_TYPE, APPLICATION_STREAM);
     request.setHeader(X_MS_VERSION, FILES_AUTHORIZATION_VERSION);
     request.setHeader(X_MS_DATE, storage_utils:getCurrentDate());
-    string resourcePathForSharedkeyAuth = azureDirectoryPath is () ? (fileShareName + SLASH + azureFileName) : 
+    string resourcePathForSharedkeyAuth = azureDirectoryPath is () ? (fileShareName + SLASH + azureFileName) :
         (fileShareName + SLASH + azureDirectoryPath + SLASH + azureFileName);
     AuthorizationDetail authorizationDetail = {
         azureRequest: request,
@@ -450,7 +461,7 @@ isolated function addPutRangeHeadersForSharedKey(http:Request request, string fi
         resourcePath: resourcePathForSharedkeyAuth,
         requiredURIParameters: requiredURIParameters
     };
-    check prepareAuthorizationHeaders(authorizationDetail); 
+    check prepareAuthorizationHeaders(authorizationDetail);
 }
 
 # Gets the header value from an HTTP response.
@@ -489,14 +500,14 @@ isolated function getMetaDataHeaders(http:Response response) returns map<string>
     string[] headerNames = response.getHeaderNames();
     foreach string header in headerNames {
         if (header.indexOf(X_MS_META) == 0) {
-            metadataHeaders[header] =  getHeaderFromResponse(response, header);
-        }   
+            metadataHeaders[header] = getHeaderFromResponse(response, header);
+        }
     }
     return metadataHeaders;
 }
 
 # Creates FileMetadataResult from http response.
-# 
+#
 # + response - Validated http response
 # + return - Returns FileMetadataResult type
 isolated function getMetadataFromResponse(http:Response response) returns FileMetadataResult {
@@ -507,4 +518,13 @@ isolated function getMetadataFromResponse(http:Response response) returns FileMe
         responseHeaders: getHeaderMapFromResponse(response)
     };
     return fileMetadataResult;
+}
+
+isolated function convertXMLToJson(xml input) returns json|ProcessingError {
+    json|xmldata:Error jsonResult = xmldata:toJson(input);
+    if jsonResult is xmldata:Error {
+        return error ProcessingError("Error while convertiong XML data to Json");
+    } else {
+        return jsonResult;
+    }
 }


### PR DESCRIPTION
# Description

# Description

This PR contains following updates to the error handling. 

1. Every client operation now returns `Error`
2. `Error` can be either `ServerError` or `ClientError`. Former represents errors created by responses from server (app level errors). Latter represents http client transport level errors or data transformation errors at client side. 
3. Server error detail contains HTTP status code, also it has error sub-types as defined by Microsoft in their documentation. 


Related issue: https://github.com/wso2-enterprise/choreo/issues/18427