### PR TITLE
Return `ResponseHeaders` record instead of map<json>

### DIFF
--- a/storageservice/Ballerina.toml
+++ b/storageservice/Ballerina.toml
@@ -2,7 +2,7 @@
 distribution = "2201.3.2"
 org = "ballerinax"
 name = "azure_storage_service"
-version = "4.1.0"
+version = "4.2.0"
 authors = ["Ballerina"]
 export = ["azure_storage_service", "azure_storage_service.files", "azure_storage_service.blobs"]
 keywords = ["Content & Files/File Management & Storage", "Cost/Paid", "Vendor/Microsoft"]

--- a/storageservice/modules/blobs/data_mappings.bal
+++ b/storageservice/modules/blobs/data_mappings.bal
@@ -25,7 +25,7 @@ isolated function convertResponseToAccountInformationType(http:Response response
         accountKind: getHeaderFromResponse(response, X_MS_ACCOUNT_KIND),
         skuName: getHeaderFromResponse(response, X_MS_SKU_NAME),
         isHNSEnabled: getHeaderFromResponse(response, X_MS_IS_HNS_ENABLED),
-        responseHeaders: getHeaderMapFromResponse(response)
+        responseHeaders: getResponseHeaders(response)
     };
     return accountInformation;
 }
@@ -44,7 +44,7 @@ isolated function convertResponseToContainerPropertiesResult(http:Response respo
         leaseState: getHeaderFromResponse(response, X_MS_LEASE_STATE),
         hasImmutabilityPolicy: getHeaderFromResponse(response, X_MS_HAS_IMMUTABILITY_POLICY),
         hasLegalHold: getHeaderFromResponse(response, X_MS_HAS_LEGAL_HOLD),
-        responseHeaders: getHeaderMapFromResponse(response)
+        responseHeaders: getResponseHeaders(response)
     };
 
     if (response.hasHeader(X_MS_LEASE_DURATION)) {
@@ -66,7 +66,7 @@ isolated function convertResponseToContainerMetadataResult(http:Response respons
         metadata: getMetaDataHeaders(response),
         eTag: getHeaderFromResponse(response, ETAG),
         lastModified: getHeaderFromResponse(response, LAST_MODIFIED),
-        responseHeaders: getHeaderMapFromResponse(response)
+        responseHeaders: getResponseHeaders(response)
     };
     return containerMetadataResult;
 }
@@ -80,7 +80,7 @@ isolated function convertResponseToContainerACLResult(http:Response response) re
     ContainerACLResult containerACLResult = {
         eTag: getHeaderFromResponse(response, ETAG),
         lastModified: getHeaderFromResponse(response, LAST_MODIFIED),
-        responseHeaders: getHeaderMapFromResponse(response)
+        responseHeaders: getResponseHeaders(response)
     };
     if (response.hasHeader(X_MS_BLOB_PUBLIC_ACCESS)) {
         containerACLResult.publicAccess = getHeaderFromResponse(response, X_MS_BLOB_PUBLIC_ACCESS);
@@ -101,7 +101,7 @@ isolated function convertResponseToBlobMetadataResult(http:Response response) re
         metadata: getMetaDataHeaders(response),
         eTag: getHeaderFromResponse(response, ETAG),
         lastModified: getHeaderFromResponse(response, LAST_MODIFIED),
-        responseHeaders: getHeaderMapFromResponse(response)
+        responseHeaders: getResponseHeaders(response)
     };
     return blobMetadataResult;
 }
@@ -116,7 +116,7 @@ isolated function convertResponseToAppendBlockResult(http:Response response) ret
         lastModified: getHeaderFromResponse(response, LAST_MODIFIED),
         blobAppendOffset: getHeaderFromResponse(response, X_MS_BLOB_APPEND_OFFSET),
         blobCommitedBlockCount: getHeaderFromResponse(response, X_MS_BLOB_COMMITTED_BLOCK_COUNT),
-        responseHeaders: getHeaderMapFromResponse(response)
+        responseHeaders: getResponseHeaders(response)
     };
     return appendBlockResult;
 }
@@ -130,7 +130,7 @@ isolated function convertResponseToPutPageResult(http:Response response) returns
         eTag: getHeaderFromResponse(response, ETAG),
         lastModified: getHeaderFromResponse(response, LAST_MODIFIED),
         blobSequenceNumber: getHeaderFromResponse(response, X_MS_BLOB_SEQUENCE_NUMBER),
-        responseHeaders: getHeaderMapFromResponse(response)
+        responseHeaders: getResponseHeaders(response)
     };
     return putPageResult;
 }
@@ -145,7 +145,7 @@ isolated function convertResponseToCopyBlobResult(http:Response response) return
         lastModified: getHeaderFromResponse(response, LAST_MODIFIED),
         copyId: getHeaderFromResponse(response, X_MS_COPY_ID),
         copyStatus: getHeaderFromResponse(response, X_MS_COPY_STATUS),
-        responseHeaders: getHeaderMapFromResponse(response)
+        responseHeaders: getResponseHeaders(response)
     };
     return copyBlobResult;
 }

--- a/storageservice/modules/blobs/endpoint.bal
+++ b/storageservice/modules/blobs/endpoint.bal
@@ -101,7 +101,7 @@ public isolated client class BlobClient {
         ListContainerResult listContainerResult = {
             containerList: check convertJSONToContainerArray(jsonContainerList.Containers.Container),
             nextMarker: (xmlListContainerResponse/<NextMarker>/*).toString(),
-            responseHeaders: getHeaderMapFromResponse(response)
+            responseHeaders: getResponseHeaders(response)
         };
         return listContainerResult;
     }
@@ -154,7 +154,7 @@ public isolated client class BlobClient {
         ListBlobResult listBlobResult = {
             blobList: check convertJSONToBlobArray(jsonBlobList.Blobs.Blob),
             nextMarker: (xmlListBlobsResponse/<NextMarker>/*).toString(),
-            responseHeaders: getHeaderMapFromResponse(response)
+            responseHeaders: getResponseHeaders(response)
         };
         return listBlobResult;
     }
@@ -189,7 +189,7 @@ public isolated client class BlobClient {
         http:Response response = <http:Response>check self.httpClient->get(path, headerMap);
         BlobResult blobResult = {
             blobContent: <byte[]>check handleGetBlobResponse(response),
-            responseHeaders: getHeaderMapFromResponse(response),
+            responseHeaders: getResponseHeaders(response),
             properties: getBlobPropertyHeaders(response)
         };
         return blobResult;
@@ -230,7 +230,7 @@ public isolated client class BlobClient {
     @display {label: "Get Blob Properties"}
     remote isolated function getBlobProperties(@display {label: "Container Name"} string containerName,
             @display {label: "Blob Name"} string blobName)
-                                                returns @display {label: "Blob properties"} map<json>|Error {
+                                                returns @display {label: "Blob properties"} ResponseHeaders|Error {
         http:Request request = new;
         setDefaultHeaders(request);
 
@@ -244,7 +244,7 @@ public isolated client class BlobClient {
         map<string> headerMap = populateHeaderMapFromRequest(request);
         http:Response response = <http:Response>check self.httpClient->head(path, headerMap);
         _ = check handleResponse(response);
-        return getHeaderMapFromResponse(response);
+        return getResponseHeaders(response);
     }
 
     # Gets Block List.
@@ -273,7 +273,7 @@ public isolated client class BlobClient {
         http:Response response = <http:Response>check self.httpClient->get(path, headerMap);
         BlockListResult blockListResult = {
             blockList: check convertXMLToJson((<xml>check handleResponse(response))),
-            responseHeaders: getHeaderMapFromResponse(response)
+            responseHeaders: getResponseHeaders(response)
         };
         return blockListResult;
     }
@@ -294,7 +294,7 @@ public isolated client class BlobClient {
             @display {label: "Blob Content"} byte[] blob = [],
             @display {label: "Blob Properties"} Properties? properties = (),
             @display {label: "Page Blob Length"} int?
-                                    pageBlobLength = ()) returns @display {label: "Response"} map<json>|Error {
+                                    pageBlobLength = ()) returns @display {label: "Response"} ResponseHeaders|Error {
         if (blob.length() > MAX_BLOB_UPLOAD_SIZE) {
             return error(AZURE_BLOB_ERROR_CODE, message = ("Blob content exceeds max supported size of 50MB"));
         }
@@ -330,7 +330,7 @@ public isolated client class BlobClient {
         string path = preparePath(self.authorizationMethod, self.accessKeyOrSAS, {}, resourcePath);
         http:Response response = <http:Response>check self.httpClient->put(path, request);
         _ = check handleResponse(response);
-        return getHeaderMapFromResponse(response);
+        return getResponseHeaders(response);
     }
 
     # Puts Blob From URL - creates a new Block Blob where the content of the blob is read from a given URL.
@@ -345,7 +345,7 @@ public isolated client class BlobClient {
             @display {label: "Blob Name"} string blobName,
             @display {label: "Source Blob URL"} string sourceBlobURL,
             @display {label: "Blob Properties"} Properties? properties = ())
-                                            returns @display {label: "Response"} map<json>|Error {
+                                            returns @display {label: "Response"} ResponseHeaders|Error {
         http:Request request = new;
         setDefaultHeaders(request);
 
@@ -364,7 +364,7 @@ public isolated client class BlobClient {
         string path = preparePath(self.authorizationMethod, self.accessKeyOrSAS, {}, resourcePath);
         http:Response response = <http:Response>check self.httpClient->put(path, request);
         _ = check handleResponse(response);
-        return getHeaderMapFromResponse(response);
+        return getResponseHeaders(response);
     }
 
     # Sets Blob Metadata.
@@ -377,7 +377,7 @@ public isolated client class BlobClient {
     remote isolated function setBlobMetadata(@display {label: "Container Name"} string containerName,
             @display {label: "Blob Name"} string blobName,
             @display {label: "Metadata"} map<string> metadata)
-                                            returns @display {label: "Response"} map<json>|Error {
+                                            returns @display {label: "Response"} ResponseHeaders|Error {
         http:Request request = new;
         setDefaultHeaders(request);
         map<string> uriParameterMap = {};
@@ -394,7 +394,7 @@ public isolated client class BlobClient {
         string path = preparePath(self.authorizationMethod, self.accessKeyOrSAS, uriParameterMap, resourcePath);
         http:Response response = <http:Response>check self.httpClient->put(path, request);
         _ = check handleResponse(response);
-        return getHeaderMapFromResponse(response);
+        return getResponseHeaders(response);
     }
 
     # Deletes a blob from a container.
@@ -405,7 +405,7 @@ public isolated client class BlobClient {
     @display {label: "Delete Blob"}
     remote isolated function deleteBlob(@display {label: "Container Name"} string containerName,
             @display {label: "Blob Name"} string blobName)
-                                        returns @display {label: "Response"} map<json>|Error {
+                                        returns @display {label: "Response"} ResponseHeaders|Error {
         http:Request request = new;
         setDefaultHeaders(request);
 
@@ -418,7 +418,7 @@ public isolated client class BlobClient {
         string path = preparePath(self.authorizationMethod, self.accessKeyOrSAS, {}, resourcePath);
         http:Response response = <http:Response>check self.httpClient->delete(path, request);
         _ = check handleResponse(response);
-        return getHeaderMapFromResponse(response);
+        return getResponseHeaders(response);
     }
 
     # Copies a blob from a URL.
@@ -460,7 +460,7 @@ public isolated client class BlobClient {
             @display {label: "Blob Name"} string blobName,
             @display {label: "Block Id"} string blockId,
             @display {label: "Blob Content"} byte[] content)
-                                    returns @display {label: "Response"} map<json>|Error {
+                                    returns @display {label: "Response"} ResponseHeaders|Error {
         http:Request request = new;
         setDefaultHeaders(request);
         map<string> uriParameterMap = {};
@@ -479,7 +479,7 @@ public isolated client class BlobClient {
         string path = preparePath(self.authorizationMethod, self.accessKeyOrSAS, uriParameterMap, resourcePath);
         http:Response response = <http:Response>check self.httpClient->put(path, request);
         _ = check handleResponse(response);
-        return getHeaderMapFromResponse(response);
+        return getResponseHeaders(response);
     }
 
     # Commits a new block to be commited as part of a blob where the content is read from a URL.
@@ -496,7 +496,7 @@ public isolated client class BlobClient {
             @display {label: "Block Id"} string blockId,
             @display {label: "Source Blob URL"} string sourceBlobURL,
             @display {label: "Byte Range"} ByteRange? byteRange = ())
-                                            returns @display {label: "Response"} map<json>|Error {
+                                            returns @display {label: "Response"} ResponseHeaders|Error {
         http:Request request = new;
         setDefaultHeaders(request);
         map<string> uriParameterMap = {};
@@ -521,7 +521,7 @@ public isolated client class BlobClient {
         string path = preparePath(self.authorizationMethod, self.accessKeyOrSAS, uriParameterMap, resourcePath);
         http:Response response = <http:Response>check self.httpClient->put(path, request);
         _ = check handleResponse(response);
-        return getHeaderMapFromResponse(response);
+        return getResponseHeaders(response);
     }
 
     # Writes a blob by specifying the list of blockIDs that make up the blob.
@@ -536,7 +536,7 @@ public isolated client class BlobClient {
             @display {label: "Blob Name"} string blobName,
             @display {label: "Block Id List"} string[] blockIdList,
             @display {label: "Blob Properties"} Properties? properties = ())
-                                        returns @display {label: "Response"} map<json>|Error {
+                                        returns @display {label: "Response"} ResponseHeaders|Error {
         if (blockIdList.length() < 1) {
             return error(AZURE_BLOB_ERROR_CODE, message = ("blockIdList cannot be empty"));
         }
@@ -576,7 +576,7 @@ public isolated client class BlobClient {
         string path = preparePath(self.authorizationMethod, self.accessKeyOrSAS, uriParameterMap, resourcePath);
         http:Response response = <http:Response>check self.httpClient->put(path, request);
         _ = check handleResponse(response);
-        return getHeaderMapFromResponse(response);
+        return getResponseHeaders(response);
     }
 
     # Updates or adds a new page Blob.
@@ -659,7 +659,7 @@ public isolated client class BlobClient {
         http:Response response = <http:Response>check self.httpClient->get(path, headerMap);
         PageRangeResult pageRangeResult = {
             pageList: check convertXMLToJson((<xml>check handleResponse(response))),
-            responseHeaders: getHeaderMapFromResponse(response)
+            responseHeaders: getResponseHeaders(response)
         };
         return pageRangeResult;
     }

--- a/storageservice/modules/blobs/management_client.bal
+++ b/storageservice/modules/blobs/management_client.bal
@@ -84,7 +84,7 @@ public isolated client class ManagementClient {
     @display {label: "Create Container"}
     remote isolated function createContainer(@display {label: "Container Name"} string containerName,
             AccessLevel? accessLevel = (), map<string>? metadata = (), string? clientRequestId = ()) returns
-    @display {label: "Response"} map<json>|Error {
+    @display {label: "Response"} ResponseHeaders|Error {
         http:Request request = new;
         setDefaultHeaders(request);
         map<string> uriParameterMap = {};
@@ -100,7 +100,7 @@ public isolated client class ManagementClient {
         string path = preparePath(self.authorizationMethod, self.accessKeyOrSAS, uriParameterMap, resourcePath);
         http:Response response = <http:Response>check self.httpClient->put(path, request);
         _ = check handleResponse(response);
-        return getHeaderMapFromResponse(response);
+        return getResponseHeaders(response);
     }
 
     # Delete a container from the azure storage account.
@@ -112,7 +112,7 @@ public isolated client class ManagementClient {
     # + return - If successful, returns Response. Else returns Error. 
     @display {label: "Delete Container"}
     remote isolated function deleteContainer(@display {label: "Container Name"} string containerName,
-            string? clientRequestId = (), string? leaseId = ()) returns @display {label: "Response"} map<json>|Error {
+            string? clientRequestId = (), string? leaseId = ()) returns @display {label: "Response"} ResponseHeaders|Error {
         http:Request request = new;
         setDefaultHeaders(request);
         map<string> uriParameterMap = {};
@@ -128,7 +128,7 @@ public isolated client class ManagementClient {
         string path = preparePath(self.authorizationMethod, self.accessKeyOrSAS, uriParameterMap, resourcePath);
         http:Response response = <http:Response>check self.httpClient->delete(path, request);
         _ = check handleResponse(response);
-        return getHeaderMapFromResponse(response);
+        return getResponseHeaders(response);
     }
 
     # Get Container Properties.
@@ -252,7 +252,7 @@ public isolated client class ManagementClient {
         xml blobServiceProperties = <xml>check handleResponse(response);
         BlobServicePropertiesResult blobServicePropertiesResult = {
             storageServiceProperties: check convertXMLToJson(blobServiceProperties/*),
-            responseHeaders: getHeaderMapFromResponse(response)
+            responseHeaders: getResponseHeaders(response)
         };
         return blobServicePropertiesResult;
     }

--- a/storageservice/modules/blobs/tests/test.bal
+++ b/storageservice/modules/blobs/tests/test.bal
@@ -190,7 +190,7 @@ function testGetBlob() returns error? {
 }
 function testSetBlobMetadata() returns error? {
     log:printInfo("blobClient -> setBlobMetadata()");
-    map<json> response = check blobClient->setBlobMetadata(TEST_CONTAINER, TEST_BLOCK_BLOB_TXT, testMetadata2);
+    ResponseHeaders response = check blobClient->setBlobMetadata(TEST_CONTAINER, TEST_BLOCK_BLOB_TXT, testMetadata2);
     log:printInfo(response.toString());
 }
 

--- a/storageservice/modules/blobs/types.bal
+++ b/storageservice/modules/blobs/types.bal
@@ -46,7 +46,18 @@ public type AccountInformationResult record {
     string skuName;
     string accountKind;
     string isHNSEnabled;
-    map<json> responseHeaders;
+    ResponseHeaders responseHeaders;
+};
+
+# Represents Response headers.
+#
+# + Date - A UTC date/time value that indicates the time at which the response was initiated  
+# + x\-ms\-version - Indicates the version of Blob Storage used to run the request 
+# + x\-ms\-request\-id - Uniquely identifies the request that was made, and can be used for troubleshooting
+public type ResponseHeaders record {
+    string Date;
+    string x\-ms\-version;
+    string x\-ms\-request\-id;
 };
 
 # Represents Azure Storage Container.
@@ -109,7 +120,7 @@ public type BlobProperties record {
 public type ListContainerResult record {|
     Container[] containerList;
     string nextMarker;
-    map<json> responseHeaders;
+    ResponseHeaders responseHeaders;
 |};
 
 # Represents List Blob Result.
@@ -120,7 +131,7 @@ public type ListContainerResult record {|
 public type ListBlobResult record {
     Blob[] blobList;
     string nextMarker;
-    map<json> responseHeaders;
+    ResponseHeaders responseHeaders;
 };
 
 # Represents Blob Service Properties Result.
@@ -129,7 +140,7 @@ public type ListBlobResult record {
 # + responseHeaders - Response headers from Azure
 public type BlobServicePropertiesResult record {
     json storageServiceProperties;
-    map<json> responseHeaders;
+    ResponseHeaders responseHeaders;
 };
 
 # Represents Blob Result.
@@ -139,7 +150,7 @@ public type BlobServicePropertiesResult record {
 # + responseHeaders - Response headers from Azure
 public type BlobResult record {|
     byte[] blobContent;
-    map<json> responseHeaders;
+    ResponseHeaders responseHeaders;
     Properties properties;
 |};
 
@@ -178,7 +189,7 @@ public type ContainerPropertiesResult record {
     string hasImmutabilityPolicy;
     string hasLegalHold;
     map<string> metaData;
-    map<json> responseHeaders;
+    ResponseHeaders responseHeaders;
 };
 
 # Represents Container Metadata Result.
@@ -191,7 +202,7 @@ public type ContainerMetadataResult record {
     map<string> metadata;
     string eTag;
     string lastModified;
-    map<json> responseHeaders;
+    ResponseHeaders responseHeaders;
 };
 
 # Represents Blob Metadata Result.
@@ -204,7 +215,7 @@ public type BlobMetadataResult record {
     map<string> metadata;
     string eTag;
     string lastModified;
-    map<json> responseHeaders;
+    ResponseHeaders responseHeaders;
 };
 
 # Represents Container ACL Result.
@@ -219,7 +230,7 @@ public type ContainerACLResult record {
     string publicAccess?;
     string eTag;
     string lastModified;
-    map<json> responseHeaders;
+    ResponseHeaders responseHeaders;
 };
 
 # Represents Block List Result.
@@ -228,7 +239,7 @@ public type ContainerACLResult record {
 # + responseHeaders - Response headers from Azure
 public type BlockListResult record {
     json blockList;
-    map<json> responseHeaders;
+    ResponseHeaders responseHeaders;
 };
 
 # Represents Copy Blob Result.
@@ -243,7 +254,7 @@ public type CopyBlobResult record {
     string copyStatus;
     string lastModified;
     string eTag;
-    map<json> responseHeaders;
+    ResponseHeaders responseHeaders;
 };
 
 # Represents Page Range Result.
@@ -252,7 +263,7 @@ public type CopyBlobResult record {
 # + responseHeaders - Response headers from Azure
 public type PageRangeResult record {
     json pageList;
-    map<json> responseHeaders;
+    ResponseHeaders responseHeaders;
 };
 
 # Represents PutPage Result.
@@ -265,7 +276,7 @@ public type PutPageResult record {
     string blobSequenceNumber;
     string eTag;
     string lastModified;
-    map<json> responseHeaders;
+    ResponseHeaders responseHeaders;
 };
 
 # Represents AppendBlock Result.
@@ -280,7 +291,7 @@ public type AppendBlockResult record {
     string blobCommitedBlockCount;
     string eTag;
     string lastModified;
-    map<json> responseHeaders;
+    ResponseHeaders responseHeaders;
 };
 
 # Represents Byte Range of a blob

--- a/storageservice/modules/blobs/utils.bal
+++ b/storageservice/modules/blobs/utils.bal
@@ -199,13 +199,26 @@ isolated function createErrorFromXMLResponse(http:Response response) returns Ser
 #
 # + response - HTTP response
 # + return - Returns header map
-isolated function getHeaderMapFromResponse(http:Response response) returns map<json> {
-    map<json> headerMap = {};
+isolated function getHeaderMapFromResponse(http:Response response) returns map<string> {
+    map<string> headerMap = {};
     string[] headerNames = response.getHeaderNames();
     foreach string header in headerNames {
         headerMap[header] = getHeaderFromResponse(response, header);
     }
     return headerMap;
+}
+
+isolated function getResponseHeaders(http:Response response) returns ResponseHeaders {
+    map<string> headers = getHeaderMapFromResponse(response);
+    ResponseHeaders responseHeaders = {
+        Date: "",
+        x\-ms\-request\-id: "",
+        x\-ms\-version: ""
+    };
+    foreach var [header, value] in headers.entries() {
+        responseHeaders[header] = value;
+    }
+    return responseHeaders;
 }
 
 # Gets the header value from an HTTP response.

--- a/storageservice/modules/files/records.bal
+++ b/storageservice/modules/files/records.bal
@@ -343,6 +343,17 @@ public type ContentRange record {|
     int endByte;
 |};
 
+# Represents Response headers.
+#
+# + Date - A UTC date/time value that indicates the time at which the response was initiated  
+# + x\-ms\-version - Indicates the service version that was used to execute the request 
+# + x\-ms\-request\-id - Uniquely identifies the request that was made, and can be used for troubleshooting
+public type ResponseHeaders record {
+    string Date;
+    string x\-ms\-version;
+    string x\-ms\-request\-id;
+};
+
 # Represents File Metadata Result.
 #
 # + metadata - Metadata of file
@@ -353,7 +364,7 @@ public type FileMetadataResult record {
     map<string> metadata;
     string eTag;
     string lastModified;
-    map<json> responseHeaders;
+    ResponseHeaders responseHeaders;
 };
 
 # Represents optional request headers for CreateShareHeaders operation.

--- a/storageservice/modules/files/utils.bal
+++ b/storageservice/modules/files/utils.bal
@@ -478,17 +478,30 @@ isolated function getHeaderFromResponse(http:Response response, string headerNam
     }
 }
 
-# Creates a map<json> of headers from an http response.
+# Creates a map<string> of headers from an http response.
 #
 # + response - HTTP response
 # + return - Returns header map
-isolated function getHeaderMapFromResponse(http:Response response) returns map<json> {
-    map<json> headerMap = {};
+isolated function getHeaderMapFromResponse(http:Response response) returns map<string> {
+    map<string> headerMap = {};
     string[] headerNames = response.getHeaderNames();
     foreach string header in headerNames {
         headerMap[header] = getHeaderFromResponse(response, header);
     }
     return headerMap;
+}
+
+isolated function getResponseHeaders(http:Response response) returns ResponseHeaders {
+    map<string> headers = getHeaderMapFromResponse(response);
+    ResponseHeaders responseHeaders = {
+        Date: "",
+        x\-ms\-request\-id: "",
+        x\-ms\-version: ""
+    };
+    foreach var [header, value] in headers.entries() {
+        responseHeaders[header] = value;
+    }
+    return responseHeaders;
 }
 
 # Get metaData headers from a request.
@@ -515,7 +528,7 @@ isolated function getMetadataFromResponse(http:Response response) returns FileMe
         metadata: getMetaDataHeaders(response),
         eTag: getHeaderFromResponse(response, ETAG),
         lastModified: getHeaderFromResponse(response, LAST_MODIFIED),
-        responseHeaders: getHeaderMapFromResponse(response)
+        responseHeaders: getResponseHeaders(response)
     };
     return fileMetadataResult;
 }


### PR DESCRIPTION
# Description
Return ResponseHeaders record instead of map<json> 

Fixes
- https://github.com/wso2-enterprise/choreo/issues/19258

Related Pull Request
- https://github.com/ballerina-platform/module-ballerinax-azure-storage-service/pull/73

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

